### PR TITLE
Conditional logic surrounding eventstore reference

### DIFF
--- a/src/proj/EventStore.Persistence.MongoPersistence/EventStore.Persistence.MongoPersistence.csproj
+++ b/src/proj/EventStore.Persistence.MongoPersistence/EventStore.Persistence.MongoPersistence.csproj
@@ -65,15 +65,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\EventStore\EventStore.csproj" Condition="!Exists('..\..\..\output\bin\EventStore.dll')">
+    <ProjectReference Include="..\EventStore\EventStore.csproj">
       <Project>{03946843-F343-419C-88EF-3E446D08DFA6}</Project>
       <Name>EventStore</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="EventStore" Condition="Exists('..\..\..\output\bin\EventStore.dll')">
-      <HintPath>..\..\..\output\bin\EventStore.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/proj/EventStore.Serialization.Json/EventStore.Serialization.Json.csproj
+++ b/src/proj/EventStore.Serialization.Json/EventStore.Serialization.Json.csproj
@@ -52,15 +52,12 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\EventStore\EventStore.csproj" Condition="!Exists('..\..\..\output\bin\EventStore.dll')">
+    <ProjectReference Include="..\EventStore\EventStore.csproj">
       <Project>{03946843-F343-419C-88EF-3E446D08DFA6}</Project>
       <Name>EventStore</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="EventStore" Condition="Exists('..\..\..\output\bin\EventStore.dll')">
-      <HintPath>..\..\..\output\bin\EventStore.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json" Condition="$(TargetFrameworkVersion)=='v4.0'">
       <HintPath>..\..\..\lib\Json.NET\.NET 4.0\Newtonsoft.Json.dll</HintPath>
     </Reference>


### PR DESCRIPTION
These two projects reference eventstore differently from the others. The logic should work, but it seems to cause intermittent problems where sometimes my visual studio will show the reference to EventStore as missing in these projects (don't know why). 

In any case, it doesn't seem right that some projects have this conditional logic and other don't. 

Because it was causing VS to misbehave, i removed it, but if you would like all the projects to use this conditional logic, i can change the request to do that instead.
