### PR TITLE
Feature open for mongodb integration

### DIFF
--- a/src/proj/EventStore.Persistence.MongoPersistence/ExtensionMethods.cs
+++ b/src/proj/EventStore.Persistence.MongoPersistence/ExtensionMethods.cs
@@ -12,7 +12,7 @@
 	{
 		public static MongoCommit ToMongoCommit(this Commit commit, ISerialize serializer)
 		{
-		return new MongoCommit
+		    return new MongoCommit
 			{
 				Id = new MongoCommitId(commit.StreamId, commit.CommitSequence),
 				StartingStreamRevision = commit.StreamRevision - (commit.Events.Count - 1),

--- a/src/proj/EventStore.Persistence.RavenPersistence/ExtensionMethods.cs
+++ b/src/proj/EventStore.Persistence.RavenPersistence/ExtensionMethods.cs
@@ -5,7 +5,7 @@ namespace EventStore.Persistence.RavenPersistence
 	using System.Globalization;
 	using Serialization;
 
-	internal static class ExtensionMethods
+	public static class ExtensionMethods
 	{
 		public static string ToRavenCommitId(this Commit commit)
 		{

--- a/src/proj/EventStore.Persistence.SqlPersistence/CommitExtensions.cs
+++ b/src/proj/EventStore.Persistence.SqlPersistence/CommitExtensions.cs
@@ -5,7 +5,7 @@ namespace EventStore.Persistence.SqlPersistence
 	using System.Data;
 	using Serialization;
 
-	internal static class CommitExtensions
+	public static class CommitExtensions
 	{
 		private const int StreamIdIndex = 0;
 		private const int StreamRevisionIndex = 1;

--- a/src/proj/EventStore.Persistence.SqlPersistence/SqlPersistenceFactory.cs
+++ b/src/proj/EventStore.Persistence.SqlPersistence/SqlPersistenceFactory.cs
@@ -28,16 +28,31 @@ namespace EventStore.Persistence.SqlPersistence
 			this.dialect = dialect;
 		}
 
-		public virtual IPersistStreams Build()
+	    protected IConnectionFactory ConnectionFactory
+	    {
+	        get { return connectionFactory; }
+	    }
+
+	    protected ISqlDialect Dialect
+	    {
+	        get { return dialect; }
+	    }
+
+	    protected ISerialize Serializer
+	    {
+	        get { return serializer; }
+	    }
+
+	    public virtual IPersistStreams Build()
 		{
-			return new SqlPersistenceEngine(this.connectionFactory, this.GetDialect(), this.serializer);
+			return new SqlPersistenceEngine(this.ConnectionFactory, this.GetDialect(), this.Serializer);
 		}
 		protected virtual ISqlDialect GetDialect()
 		{
-			if (this.dialect != null)
-				return this.dialect;
+			if (this.Dialect != null)
+				return this.Dialect;
 
-			var settings = this.connectionFactory.Settings;
+			var settings = this.ConnectionFactory.Settings;
 			var connectionString = (settings.ConnectionString ?? string.Empty).ToUpperInvariant();
 			var providerName = (settings.ProviderName ?? string.Empty).ToUpperInvariant();
 


### PR DESCRIPTION
Last pull request. I publicized extension methods. Although they do not harm anyone, maybe you should move them to an Internals folder and still give them a public modifier. This way kittens will not get harmed when referencing the project and people can still integrate by including the [...].Internals namespace.
