### PR TITLE
Added a meaningful Exception in case ConnectionString is not present in Configuration

### DIFF
--- a/src/proj/EventStore.Persistence.SqlPersistence/ConfigurationConnectionFactory.cs
+++ b/src/proj/EventStore.Persistence.SqlPersistence/ConfigurationConnectionFactory.cs
@@ -5,8 +5,9 @@ namespace EventStore.Persistence.SqlPersistence
 	using System.Data;
 	using System.Data.Common;
 	using System.Data.SqlClient;
+	using System.Linq;
 
-	public class ConfigurationConnectionFactory : IConnectionFactory
+    public class ConfigurationConnectionFactory : IConnectionFactory
 	{
 		private const int DefaultShards = 16;
 		private const string DefaultConnectionName = "EventStore";
@@ -40,14 +41,26 @@ namespace EventStore.Persistence.SqlPersistence
 		}
 		protected virtual IDbConnection Open(Guid streamId, string connectionName)
 		{
-			var setting = ConfigurationManager.ConnectionStrings[connectionName];
+			var setting = GetConnectionStringSettings(connectionName);
 			var factory = DbProviderFactories.GetFactory(setting.ProviderName ?? DefaultProvider);
 			var connection = factory.CreateConnection() ?? new SqlConnection();
 			connection.ConnectionString = this.BuildConnectionString(streamId, setting);
 			connection.Open();
 			return connection;
 		}
-		protected virtual string BuildConnectionString(Guid streamId, ConnectionStringSettings setting)
+
+	    private ConnectionStringSettings GetConnectionStringSettings(string connectionName)
+	    {
+            var keyExists = ConfigurationManager.ConnectionStrings
+                .Cast<ConnectionStringSettings>()
+	            .Any(p => p.Name == connectionName);
+
+            if (!keyExists)
+                throw new StorageException("Could not find connectionstring '{0}' in your configuration");
+	        return ConfigurationManager.ConnectionStrings[connectionName];
+	    }
+
+	    protected virtual string BuildConnectionString(Guid streamId, ConnectionStringSettings setting)
 		{
 			if (this.shards == 0)
 				return setting.ConnectionString;


### PR DESCRIPTION
I spent like 15 minutes debugging my init code only to find out I was running inside the test project that had no App.config <connectionstrings> setting.

Since it's really annoying I thought I'd fix it at the root.

I wanted to add a test to verify the behavior, but 

a) my current machine is not set up for MSpec
b) I was not sure if the test should rather go into acceptance-persistence (wrong place IMO) or the main testproject (where it would require a reference to the sql-persistence project)

greetings Daniel
