### PR TITLE
Allow Mongo persistance wireup to take a raw connection string, as well as a connection name

### DIFF
--- a/src/proj/EventStore.Persistence.MongoPersistence.Wireup/MongoPersistenceWireup.cs
+++ b/src/proj/EventStore.Persistence.MongoPersistence.Wireup/MongoPersistenceWireup.cs
@@ -9,7 +9,7 @@ namespace EventStore
 	{
 		private static readonly ILog Logger = LogFactory.BuildLogger(typeof(MongoPersistenceWireup));
 
-		public MongoPersistenceWireup(Wireup inner, string connectionName, IDocumentSerializer serializer)
+		public MongoPersistenceWireup(Wireup inner, string connection, IDocumentSerializer serializer)
 			: base(inner)
 		{
 			Logger.Debug("Configuring Mongo persistence engine.");
@@ -19,7 +19,7 @@ namespace EventStore
 				Logger.Warn("MongoDB does not participate in transactions using TransactionScope.");
 
 			this.Container.Register(c => new MongoPersistenceFactory(
-				connectionName,
+				connection,
 				serializer).Build());
 		}
 	}

--- a/src/proj/EventStore.Persistence.MongoPersistence.Wireup/MongoPersistenceWireupExtensions.cs
+++ b/src/proj/EventStore.Persistence.MongoPersistence.Wireup/MongoPersistenceWireupExtensions.cs
@@ -4,10 +4,11 @@ namespace EventStore
 
 	public static class MongoPersistenceWireupExtensions
 	{
+        /// <param name="connection">'connectionStrings' config section name or a raw connection string</param>
 		public static PersistenceWireup UsingMongoPersistence(
-			this Wireup wireup, string connectionName, IDocumentSerializer serializer)
+			this Wireup wireup, string connection, IDocumentSerializer serializer)
 		{
-			return new MongoPersistenceWireup(wireup, connectionName, serializer);
+			return new MongoPersistenceWireup(wireup, connection, serializer);
 		}
 	}
 }

--- a/src/proj/EventStore.Persistence.MongoPersistence/MongoPersistenceFactory.cs
+++ b/src/proj/EventStore.Persistence.MongoPersistence/MongoPersistenceFactory.cs
@@ -6,12 +6,12 @@
 
 	public class MongoPersistenceFactory : IPersistenceFactory
 	{
-		private readonly string connectionName;
+		private readonly string connection;
 		private readonly IDocumentSerializer serializer;
 
-		public MongoPersistenceFactory(string connectionName, IDocumentSerializer serializer)
+		public MongoPersistenceFactory(string connection, IDocumentSerializer serializer)
 		{
-			this.connectionName = connectionName;
+			this.connection = connection;
 			this.serializer = serializer;
 		}
 
@@ -24,10 +24,11 @@
 
 		protected virtual string GetConnectionString()
 		{
-			return ConfigurationManager.ConnectionStrings[this.connectionName].ConnectionString;
+		    return connection.ToLower().StartsWith("mongodb://") ? connection :
+                ConfigurationManager.ConnectionStrings[this.connection].ConnectionString;
 		}
 
-		protected virtual string TransformConnectionString(string connectionString)
+	    protected virtual string TransformConnectionString(string connectionString)
 		{
 			return connectionString;
 		}


### PR DESCRIPTION
Hello. Whilst this code revision may seem like an odd thing to suggest, we have run up against the problem that this solves, in the real world.

Using the `connectionStrings` config section is usually the correct way to configure data stores, but in our case we are deploying to a PaaS and have no control over the location of where the connection string is stored; In our case, the connection string is held within `appSettings` and it is replaced during deployment by the PaaS provider.

In our case, our only option is for us to load the MongoDB connection string ourselves before passing it to the Mongo persistence wireup, rather than let the EventStore plugin find it for us.

I hope this makes sense.

I admit that the solution offered here has a a slight smell of compromise, but allows for backwards compatibility, it's simple and it works!

I'd be happy to take another approach to solving this issue, if you don't like the dual use of a string parameter.
