### PR TITLE
queued async dispatcher

### DIFF
--- a/src/proj/EventStore.Core/Dispatcher/AsynchronousDispatchScheduler.cs
+++ b/src/proj/EventStore.Core/Dispatcher/AsynchronousDispatchScheduler.cs
@@ -4,24 +4,53 @@ namespace EventStore.Dispatcher
 	using System.Threading;
 	using Logging;
 	using Persistence;
+    using System.Collections.Concurrent;
+    using System.Threading.Tasks;
 
 	public class AsynchronousDispatchScheduler : SynchronousDispatchScheduler
 	{
 		private static readonly ILog Logger = LogFactory.BuildLogger(typeof(AsynchronousDispatchScheduler));
+        private BlockingCollection<Commit> _queue;
+        private int _boundedCapacity = 1024;
+        private Task _worker;
+        private bool _working;
 
 		public AsynchronousDispatchScheduler(IDispatchCommits dispatcher, IPersistStreams persistence)
 			: base(dispatcher, persistence)
 		{
 		}
 
+        protected override void Start()
+        {
+            _queue = new BlockingCollection<Commit>(new ConcurrentQueue<Commit>(), _boundedCapacity);
+            _worker = new Task(Working);
+            _working = true;
+            _worker.Start();
+
+            base.Start();
+        }
+
 		public override void ScheduleDispatch(Commit commit)
 		{
 			Logger.Info(Resources.SchedulingDelivery, commit.CommitId);
-			ThreadPool.QueueUserWorkItem(x => this.Callback(commit));
+            _queue.Add(commit);
 		}
-		private void Callback(Commit commit)
-		{
-			base.ScheduleDispatch(commit);
-		}
+
+        void Working()
+        {
+            while (_working)
+            {
+                Commit commit = null;
+                if (_queue.TryTake(out commit, 100))
+                    base.ScheduleDispatch(commit);
+            }
+        }
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            _working = false;
+        }
+
 	}
+
 }

--- a/src/proj/EventStore.Core/Dispatcher/SynchronousDispatchScheduler.cs
+++ b/src/proj/EventStore.Core/Dispatcher/SynchronousDispatchScheduler.cs
@@ -36,7 +36,7 @@ namespace EventStore.Dispatcher
 			this.persistence.Dispose();
 		}
 
-		private void Start()
+		protected virtual void Start()
 		{
 			Logger.Debug(Resources.InitializingPersistence);
 			this.persistence.Initialize();


### PR DESCRIPTION
Current Async Dispatcher implementations can cause messages to be published out of order.
