### PR TITLE
fixed: mongodbpersistence wireup internalization

### DIFF
--- a/build/default.ps1
+++ b/build/default.ps1
@@ -80,7 +80,7 @@ task PackageEventStore -depends Clean, Compile {
 task PackageMongoPersistence -depends Clean, Compile,PackageEventStore {
 	mkdir $output_directory\plugins\persistence\mongo | out-null
 
-	Merge-Assemblies -outputFile "$output_directory/plugins/persistence/mongo/EventStore.Persistence.MongoPersistence.dll" -exclude "MongoDB.*" -keyfile $keyFile -files @(
+	Merge-Assemblies -outputFile "$output_directory/plugins/persistence/mongo/EventStore.Persistence.MongoPersistence.dll" -exclude "EventStore.*" -keyfile $keyFile -files @(
 		"$src_directory/proj/EventStore.Persistence.MongoPersistence/bin/$target_config/EventStore.Persistence.MongoPersistence.dll",
 		"$src_directory/proj/EventStore.Persistence.MongoPersistence.Wireup/bin/$target_config/EventStore.Persistence.MongoPersistence.Wireup.dll"
 	)


### PR DESCRIPTION
MongoDB wireup was internalized due to a wrong exclude
