### PR TITLE
Fixed ILMerge issue with MongoPersistence

### DIFF
--- a/build/default.ps1
+++ b/build/default.ps1
@@ -80,7 +80,7 @@ task PackageEventStore -depends Clean, Compile {
 task PackageMongoPersistence -depends Clean, Compile,PackageEventStore {
 	mkdir $output_directory\plugins\persistence\mongo | out-null
 
-	Merge-Assemblies -outputFile "$output_directory/plugins/persistence/mongo/EventStore.Persistence.MongoPersistence.dll" -exclude "MongoDB.*" -keyfile $keyFile -files @(
+	Merge-Assemblies -outputFile "$output_directory/plugins/persistence/mongo/EventStore.Persistence.MongoPersistence.dll" -exclude "Mongo.*" -keyfile $keyFile -files @(
 		"$src_directory/proj/EventStore.Persistence.MongoPersistence/bin/$target_config/EventStore.Persistence.MongoPersistence.dll",
 		"$src_directory/proj/EventStore.Persistence.MongoPersistence.Wireup/bin/$target_config/EventStore.Persistence.MongoPersistence.Wireup.dll"
 	)


### PR DESCRIPTION
EventStore namespace from the MongoPersistence.Wireup project was not merged properly.

I _guess_ that this had to do with the Wireup assembly being internalized, instead of merged.
