### PR TITLE
Fix for SQL Server Ce max payload of 8000

### DIFF
--- a/src/proj/EventStore.Persistence.SqlPersistence/SqlDialects/SqlCeDialect.cs
+++ b/src/proj/EventStore.Persistence.SqlPersistence/SqlDialects/SqlCeDialect.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace EventStore.Persistence.SqlPersistence.SqlDialects
 {
 	using System;
@@ -70,6 +72,20 @@ namespace EventStore.Persistence.SqlPersistence.SqlDialects
 				: base(dialect, scope, connection, transaction)
 			{
 			}
+            
+            protected override void SetParameterValue(IDataParameter param, object value, DbType? type)
+            {
+                base.SetParameterValue(param, value, null);
+
+                // SQL CE Binary has a size limit of 8000. We have to explicitely set the type of the parameter to SqlDbType.Image 
+                // to be able to support a larger payload.
+                if (param.DbType == DbType.Binary)
+                {
+                    param.GetType().InvokeMember("SqlDbType",
+                                                 BindingFlags.Instance | BindingFlags.Public | BindingFlags.SetProperty,
+                                                 Type.DefaultBinder, param, new object[] { SqlDbType.Image });
+                }
+            }
 		}
 	}
 }


### PR DESCRIPTION
Fix for the following issue:

https://github.com/joliver/EventStore/issues/136

It feels a bit like a hack, but we have to explicitly set the type of the parameter to Image, so I don't see another way.
