### PR TITLE
Change payload column definition in table Commits for MySql dialect.

### DIFF
--- a/src/proj/EventStore.Persistence.SqlPersistence/SqlDialects/MySqlStatements.resx
+++ b/src/proj/EventStore.Persistence.SqlPersistence/SqlDialects/MySqlStatements.resx
@@ -128,7 +128,7 @@
        CommitStamp bigint NOT NULL,
        Dispatched bit NOT NULL DEFAULT 0,
        Headers blob NULL,
-       Payload blob NOT NULL,
+       Payload mediumblob NOT NULL,
        CONSTRAINT PK_Commits PRIMARY KEY (StreamId, CommitSequence)
 );
 CREATE UNIQUE INDEX IX_Commits_CommitId ON Commits (StreamId, CommitId);


### PR DESCRIPTION
Changed from blob to mediumblob. This changes the effective maximum size
from 64KB to 24MB which is more in line with the sizes of blob columns in
other Sql dialects.
We hit the 64KB limit with a payload and would like to extend it.
