### PR TITLE
Got Mongo xunit acceptance tests passing

### DIFF
--- a/src/proj/EventStore.Persistence.MongoPersistence/MongoPersistenceEngine.cs
+++ b/src/proj/EventStore.Persistence.MongoPersistence/MongoPersistenceEngine.cs
@@ -116,7 +116,7 @@
 
 			return this.TryMongo(() => this.PersistedCommits
 				.Find(Query.GTE("CommitStamp", start))
-				.SetSortOrder("CommitStamp")
+                .SetSortOrder("_id")
 				.Select(x => x.ToCommit(this.serializer)));
 		}
 
@@ -126,7 +126,7 @@
 
 			return this.TryMongo(() => this.PersistedCommits
 				.Find(Query.And(Query.GTE("CommitStamp", start), Query.LT("CommitStamp", end)))
-				.SetSortOrder("CommitStamp")
+                .SetSortOrder("_id")
 				.Select(x => x.ToCommit(this.serializer)));
 		}
 
@@ -167,7 +167,7 @@
 
 			return this.TryMongo(() => this.PersistedCommits
 				.Find(Query.EQ("Dispatched", false))
-				.SetSortOrder("CommitStamp")
+                .SetSortOrder("_id")
 				.Select(mc => mc.ToCommit(this.serializer)));
 		}
 		public virtual void MarkCommitAsDispatched(Commit commit)

--- a/src/tests/EventStore.Persistence.MongoPersistence.Tests/AcceptanceTests/PersistenceEngineFixture.cs
+++ b/src/tests/EventStore.Persistence.MongoPersistence.Tests/AcceptanceTests/PersistenceEngineFixture.cs
@@ -6,7 +6,7 @@ namespace EventStore.Persistence.AcceptanceTests
     {
         public PersistenceEngineFixture()
         {
-            this.createPersistence = () => 
+            this.createPersistence = () =>
                 new AcceptanceTestMongoPersistenceFactory().Build();
         }
     }


### PR DESCRIPTION
I don't like the change I had to make to get the acceptance tests to pass with the existing schema. It sorts on the "_id" property instead of CommitStamp. the "_id" property consists of <StreamIdGuid>/<CommitSequence>. This is slower than sorting by commit stamp.

Another option is to add an extra CommitSequence property to the document, then sort by CommitStamp, then by CommitSequence. This would be a schema change. Existing databases would still work. However, it would return the commits out of sequence if 2 commits were committed at the same time and they don't have CommitSequence populated. This is the way it's working now, so I wonder if this would be a better approach.
