### PR TITLE
Get rid of the remains of the EventStore namespace

### DIFF
--- a/src/NEventStore.Persistence.MongoPersistence.Tests/AcceptanceTestMongoPersistenceFactory.cs
+++ b/src/NEventStore.Persistence.MongoPersistence.Tests/AcceptanceTestMongoPersistenceFactory.cs
@@ -1,4 +1,4 @@
-﻿namespace EventStore.Persistence.MongoPersistence.Tests
+﻿namespace NEventStore.Persistence.MongoPersistence.Tests
 {
     using System;
     using NEventStore.Persistence.MongoPersistence;

--- a/src/NEventStore.Persistence.MongoPersistence.Tests/AcceptanceTests/PersistenceEngineFixture.cs
+++ b/src/NEventStore.Persistence.MongoPersistence.Tests/AcceptanceTests/PersistenceEngineFixture.cs
@@ -1,6 +1,6 @@
 ﻿namespace NEventStore.Persistence.AcceptanceTests
 {
-    using EventStore.Persistence.MongoPersistence.Tests;
+    using NEventStore.Persistence.MongoPersistence.Tests;
 
     public partial class PersistenceEngineFixture
     {

--- a/src/NEventStore.Persistence.RavenPersistence/RavenPersistenceWireup.cs
+++ b/src/NEventStore.Persistence.RavenPersistence/RavenPersistenceWireup.cs
@@ -1,4 +1,4 @@
-namespace EventStore
+namespace NEventStore
 {
     using System;
     using System.Collections.Generic;

--- a/src/NEventStore.Persistence.RavenPersistence/RavenPersistenceWireupExtensions.cs
+++ b/src/NEventStore.Persistence.RavenPersistence/RavenPersistenceWireupExtensions.cs
@@ -1,4 +1,4 @@
-namespace EventStore
+namespace NEventStore
 {
     using NEventStore;
 


### PR DESCRIPTION
If one wanted to wire up NEventStore with UsingRavenPersistence(), then it was unfortunately required to add a 'using EventStore;' right next to your 'using NEventStore;'.

It was an easy fix to just change the remaining EventStore namespaces to NEventStore.
