### PR TITLE
fixed Guard check

### DIFF
--- a/src/NEventStore/Guard.cs
+++ b/src/NEventStore/Guard.cs
@@ -7,13 +7,12 @@
 
     internal static class Guard
     {
-        internal static void Not(bool condition, Func<Exception> createException)
+        internal static void NotFalse(bool condition, Func<Exception> createException)
         {
             if (!condition)
             {
-                return;
+                throw createException();
             }
-            throw createException();
         }
 
         internal static void NotNullOrWhiteSpace(Expression<Func<string>> reference, string value)

--- a/src/NEventStore/Persistence/Sql/SqlPersistenceEngine.cs
+++ b/src/NEventStore/Persistence/Sql/SqlPersistenceEngine.cs
@@ -262,7 +262,7 @@ namespace NEventStore.Persistence.Sql
         public IEnumerable<ICommit> GetFrom(string checkpointToken)
         {
             int checkpoint;
-            Guard.Not(int.TryParse(checkpointToken, out checkpoint), () => new ArgumentException("checkpointToken expected to be parsable to an int"));
+            Guard.NotFalse(int.TryParse(checkpointToken, out checkpoint), () => new ArgumentException("checkpointToken expected to be parsable to an int"));
             Logger.Debug(Messages.GettingAllCommitsFromCheckpoint, checkpointToken);
             return ExecuteQuery(query =>
             {


### PR DESCRIPTION
This fixes the parameter Guard check of SqlPersistenceEngine's GetFrom(string checkpointToken) method. Currently it throws an exception when provided with a valid parameter.
