### PR TITLE
fixed bug in GetFrom(string checkpoint) and added test

### DIFF
--- a/src/NEventStore/Guard.cs
+++ b/src/NEventStore/Guard.cs
@@ -9,7 +9,7 @@
     {
         internal static void NotFalse(bool condition, Func<Exception> createException)
         {
-            if (condition)
+            if (!condition)
             {
                 throw createException();
             }

--- a/src/NEventStore/Persistence/Sql/SqlPersistenceEngine.cs
+++ b/src/NEventStore/Persistence/Sql/SqlPersistenceEngine.cs
@@ -261,9 +261,12 @@ namespace NEventStore.Persistence.Sql
 
         public IEnumerable<ICommit> GetFrom(string checkpointToken = null)
         {
-            int checkpoint;
-            bool b = int.TryParse(checkpointToken, out checkpoint);
-            Guard.NotFalse(b, () => new ArgumentException("checkpointToken expected to be parsable to an int"));
+            int checkpoint = 0;
+            if (checkpointToken != null)
+            {
+                bool b = int.TryParse(checkpointToken, out checkpoint);
+                Guard.NotFalse(b, () => new ArgumentException("checkpointToken expected to be parsable to an int"));
+            }
             Logger.Debug(Messages.GettingAllCommitsFromCheckpoint, checkpointToken);
             return ExecuteQuery(query =>
             {


### PR DESCRIPTION
If checkPoint is null we want to load all events from the start and if checkPoint is not parsable to an int we throw an exception. The attached test succeeds with SQL persistence, not tested with Mongo etc.
