### PR TITLE
Migrated from Moq to FakeItEasy

### DIFF
--- a/src/NEventStore.Tests/Client/PollingClientTests.cs
+++ b/src/NEventStore.Tests/Client/PollingClientTests.cs
@@ -4,7 +4,9 @@
     using System.Reactive.Linq;
     using System.Reactive.Threading.Tasks;
     using System.Threading.Tasks;
-    using Moq;
+
+    using FakeItEasy;
+
     using NEventStore.Persistence;
     using NEventStore.Persistence.AcceptanceTests;
     using NEventStore.Persistence.AcceptanceTests.BDD;
@@ -22,13 +24,13 @@
         [Fact]
         public void When_interval_less_than_zero_then_should_throw()
         {
-            Catch.Exception(() => new PollingClient(new Mock<IPersistStreams>().Object,-1)).ShouldBeInstanceOf<ArgumentException>();
+            Catch.Exception(() => new PollingClient(A.Fake<IPersistStreams>(),-1)).ShouldBeInstanceOf<ArgumentException>();
         }
 
         [Fact]
         public void When_interval_is_zero_then_should_throw()
         {
-            Catch.Exception(() => new PollingClient(new Mock<IPersistStreams>().Object, 0)).ShouldBeInstanceOf<ArgumentException>();
+            Catch.Exception(() => new PollingClient(A.Fake<IPersistStreams>(), 0)).ShouldBeInstanceOf<ArgumentException>();
         }
     }
 

--- a/src/NEventStore.Tests/DispatchCommitHookTests.cs
+++ b/src/NEventStore.Tests/DispatchCommitHookTests.cs
@@ -4,7 +4,9 @@
 namespace NEventStore
 {
     using System;
-    using Moq;
+
+    using FakeItEasy;
+
     using NEventStore.Dispatcher;
     using NEventStore.Persistence;
     using NEventStore.Persistence.AcceptanceTests;
@@ -15,14 +17,14 @@ namespace NEventStore
     public class when_a_commit_has_been_persisted : SpecificationBase
     {
         private readonly ICommit _commit = new Commit(Bucket.Default, Guid.NewGuid().ToString(), 0, Guid.NewGuid(), 0, DateTime.MinValue, new LongCheckpoint(0).Value, null, null);
+        
+        private readonly IScheduleDispatches _dispatcher = A.Fake<IScheduleDispatches>();
 
-        private readonly Mock<IScheduleDispatches> _dispatcher = new Mock<IScheduleDispatches>();
         private DispatchSchedulerPipelineHook _dispatchSchedulerHook;
 
         protected override void Context()
         {
-            _dispatchSchedulerHook = new DispatchSchedulerPipelineHook(_dispatcher.Object);
-            _dispatcher.Setup(x => x.ScheduleDispatch(null));
+            _dispatchSchedulerHook = new DispatchSchedulerPipelineHook(_dispatcher);
         }
 
         protected override void Because()
@@ -33,7 +35,7 @@ namespace NEventStore
         [Fact]
         public void should_invoke_the_configured_dispatcher()
         {
-            _dispatcher.Verify(x => x.ScheduleDispatch(_commit), Times.Once());
+            A.CallTo(() => _dispatcher.ScheduleDispatch(_commit)).MustHaveHappened(Repeated.Exactly.Once);
         }
     }
 

--- a/src/NEventStore.Tests/DispatcherTests/AsynchronousDispatcherTests.cs
+++ b/src/NEventStore.Tests/DispatcherTests/AsynchronousDispatcherTests.cs
@@ -4,9 +4,10 @@
 
 namespace NEventStore.DispatcherTests
 {
-    using System.Linq;
     using System.Threading;
-    using Moq;
+
+    using FakeItEasy;
+
     using NEventStore.Dispatcher;
     using NEventStore.Persistence;
     using NEventStore.Persistence.AcceptanceTests.BDD;
@@ -14,27 +15,25 @@ namespace NEventStore.DispatcherTests
 
     public class when_instantiating_the_asynchronous_dispatch_scheduler : SpecificationBase
     {
-        private readonly Mock<IDispatchCommits> dispatcher = new Mock<IDispatchCommits>();
-        private readonly Mock<IPersistStreams> persistence = new Mock<IPersistStreams>();
+        private readonly IDispatchCommits dispatcher = A.Fake<IDispatchCommits>();
+        private readonly IPersistStreams persistence = A.Fake<IPersistStreams>();
         private ICommit[] _commits;
+        private ICommit firstCommit, lastCommit;
 
         protected override void Context()
         {
             _commits = new[]
             {
-                CommitHelper.Create(),
-                CommitHelper.Create()
+                firstCommit = CommitHelper.Create(),
+                lastCommit = CommitHelper.Create()
             };
 
-            persistence.Setup(x => x.Initialize());
-            persistence.Setup(x => x.GetUndispatchedCommits()).Returns(_commits);
-            dispatcher.Setup(x => x.Dispatch(_commits.First()));
-            dispatcher.Setup(x => x.Dispatch(_commits.Last()));
+            A.CallTo(() => persistence.GetUndispatchedCommits()).Returns(_commits);
         }
 
         protected override void Because()
         {
-            new AsynchronousDispatchScheduler(dispatcher.Object, persistence.Object);
+            new AsynchronousDispatchScheduler(dispatcher, persistence);
         }
 
         [Fact]
@@ -46,35 +45,33 @@ namespace NEventStore.DispatcherTests
         [Fact]
         public void should_initialize_the_persistence_engine()
         {
-            persistence.Verify(x => x.Initialize(), Times.Once());
+            A.CallTo(() => persistence.Initialize()).MustHaveHappened(Repeated.Exactly.Once);
         }
 
         [Fact]
         public void should_get_the_set_of_undispatched_commits()
         {
-            persistence.Verify(x => x.GetUndispatchedCommits(), Times.Once());
+            A.CallTo(() => persistence.GetUndispatchedCommits()).MustHaveHappened(Repeated.Exactly.Once);
         }
 
         [Fact]
         public void should_provide_the_commits_to_the_dispatcher()
         {
-            dispatcher.VerifyAll();
+            A.CallTo(() => dispatcher.Dispatch(firstCommit)).MustHaveHappened();
+            A.CallTo(() => dispatcher.Dispatch(lastCommit)).MustHaveHappened();
         }
     }
 
     public class when_asynchronously_scheduling_a_commit_for_dispatch : SpecificationBase
     {
         private readonly ICommit _commit = CommitHelper.Create();
-        private readonly Mock<IDispatchCommits> dispatcher = new Mock<IDispatchCommits>();
-        private readonly Mock<IPersistStreams> persistence = new Mock<IPersistStreams>();
+        private readonly IDispatchCommits dispatcher = A.Fake<IDispatchCommits>();
+        private readonly IPersistStreams persistence = A.Fake<IPersistStreams>();
         private AsynchronousDispatchScheduler dispatchScheduler;
 
         protected override void Context()
         {
-            dispatcher.Setup(x => x.Dispatch(_commit));
-            persistence.Setup(x => x.MarkCommitAsDispatched(_commit));
-
-            dispatchScheduler = new AsynchronousDispatchScheduler(dispatcher.Object, persistence.Object);
+            dispatchScheduler = new AsynchronousDispatchScheduler(dispatcher, persistence);
         }
 
         protected override void Because()
@@ -91,27 +88,25 @@ namespace NEventStore.DispatcherTests
         [Fact]
         public void should_provide_the_commit_to_the_dispatcher()
         {
-            dispatcher.Verify(x => x.Dispatch(_commit), Times.Once());
+            A.CallTo(() => dispatcher.Dispatch(_commit)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
         [Fact]
         public void should_mark_the_commit_as_dispatched()
         {
-            persistence.Verify(x => x.MarkCommitAsDispatched(_commit), Times.Once());
+            A.CallTo(() => persistence.MarkCommitAsDispatched(_commit)).MustHaveHappened(Repeated.Exactly.Once);
         }
     }
 
     public class when_disposing_the_async_dispatch_scheduler : SpecificationBase
     {
-        private readonly Mock<IDispatchCommits> dispatcher = new Mock<IDispatchCommits>();
-        private readonly Mock<IPersistStreams> persistence = new Mock<IPersistStreams>();
+        private readonly IDispatchCommits dispatcher = A.Fake<IDispatchCommits>();
+        private readonly IPersistStreams persistence = A.Fake<IPersistStreams>();
         private AsynchronousDispatchScheduler dispatchScheduler;
 
         protected override void Context()
         {
-            dispatcher.Setup(x => x.Dispose());
-            persistence.Setup(x => x.Dispose());
-            dispatchScheduler = new AsynchronousDispatchScheduler(dispatcher.Object, persistence.Object);
+            dispatchScheduler = new AsynchronousDispatchScheduler(dispatcher, persistence);
         }
 
         protected override void Because()
@@ -123,13 +118,13 @@ namespace NEventStore.DispatcherTests
         [Fact]
         public void should_dispose_the_underlying_dispatcher_exactly_once()
         {
-            dispatcher.Verify(x => x.Dispose(), Times.Once());
+            A.CallTo(() => dispatcher.Dispose()).MustHaveHappened(Repeated.Exactly.Once);
         }
 
         [Fact]
         public void should_dispose_the_underlying_persistence_infrastructure_exactly_once()
         {
-            dispatcher.Verify(x => x.Dispose(), Times.Once());
+            A.CallTo(() => persistence.Dispose()).MustHaveHappened(Repeated.Exactly.Once);
         }
     }
 }

--- a/src/NEventStore.Tests/DispatcherTests/SynchronousDispatcherTests.cs
+++ b/src/NEventStore.Tests/DispatcherTests/SynchronousDispatcherTests.cs
@@ -1,7 +1,7 @@
 namespace NEventStore.DispatcherTests
 {
-    using System.Linq;
-    using Moq;
+    using FakeItEasy;
+
     using NEventStore.Dispatcher;
     using NEventStore.Persistence;
     using NEventStore.Persistence.AcceptanceTests.BDD;
@@ -9,92 +9,86 @@ namespace NEventStore.DispatcherTests
 
     public class when_instantiating_the_synchronous_dispatch_scheduler : SpecificationBase
     {
-        private readonly Mock<IDispatchCommits> _dispatcher = new Mock<IDispatchCommits>();
-        private readonly Mock<IPersistStreams> _persistence = new Mock<IPersistStreams>();
+        private readonly IDispatchCommits dispatcher = A.Fake<IDispatchCommits>();
+        private readonly IPersistStreams persistence = A.Fake<IPersistStreams>();
         private ICommit[] _commits;
+        private ICommit firstCommit, lastCommit;
 
         protected override void Context()
         {
             _commits = new[]
             {
-                CommitHelper.Create(),
-                CommitHelper.Create()
+                firstCommit = CommitHelper.Create(),
+                lastCommit = CommitHelper.Create()
             };
 
-            _persistence.Setup(x => x.Initialize());
-            _persistence.Setup(x => x.GetUndispatchedCommits()).Returns(_commits);
-            _dispatcher.Setup(x => x.Dispatch(_commits.First()));
-            _dispatcher.Setup(x => x.Dispatch(_commits.Last()));
+            A.CallTo(() => persistence.GetUndispatchedCommits()).Returns(_commits);
         }
 
         protected override void Because()
         {
-            new SynchronousDispatchScheduler(_dispatcher.Object, _persistence.Object);
+            new SynchronousDispatchScheduler(dispatcher, persistence);
         }
 
         [Fact]
         public void should_initialize_the_persistence_engine()
         {
-            _persistence.Verify(x => x.Initialize(), Times.Once());
+            A.CallTo(() => persistence.Initialize()).MustHaveHappened(Repeated.Exactly.Once);
         }
 
         [Fact]
         public void should_get_the_set_of_undispatched_commits()
         {
-            _persistence.Verify(x => x.GetUndispatchedCommits(), Times.Once());
+            A.CallTo(() => persistence.GetUndispatchedCommits()).MustHaveHappened(Repeated.Exactly.Once);
         }
 
         [Fact]
         public void should_provide_the_commits_to_the_dispatcher()
         {
-            _dispatcher.VerifyAll();
+            A.CallTo(() => dispatcher.Dispatch(firstCommit)).MustHaveHappened();
+            A.CallTo(() => dispatcher.Dispatch(lastCommit)).MustHaveHappened();
         }
     }
 
     public class when_synchronously_scheduling_a_commit_for_dispatch : SpecificationBase
     {
-        private readonly ICommit _commitAttempt = CommitHelper.Create();
-        private readonly Mock<IDispatchCommits> _dispatcher = new Mock<IDispatchCommits>();
-        private readonly Mock<IPersistStreams> _persistence = new Mock<IPersistStreams>();
+        private readonly ICommit _commit = CommitHelper.Create();
+        private readonly IDispatchCommits dispatcher = A.Fake<IDispatchCommits>();
+        private readonly IPersistStreams persistence = A.Fake<IPersistStreams>();
         private SynchronousDispatchScheduler _dispatchScheduler;
 
         protected override void Context()
         {
-            _dispatcher.Setup(x => x.Dispatch(_commitAttempt));
-            _persistence.Setup(x => x.MarkCommitAsDispatched(_commitAttempt));
-
-            _dispatchScheduler = new SynchronousDispatchScheduler(_dispatcher.Object, _persistence.Object);
+            _dispatchScheduler = new SynchronousDispatchScheduler(dispatcher, persistence);
         }
 
         protected override void Because()
         {
-            _dispatchScheduler.ScheduleDispatch(_commitAttempt);
+            _dispatchScheduler.ScheduleDispatch(_commit);
         }
 
         [Fact]
         public void should_provide_the_commit_to_the_dispatcher()
         {
-            _dispatcher.Verify(x => x.Dispatch(_commitAttempt), Times.Once());
+            A.CallTo(() => dispatcher.Dispatch(_commit)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
         [Fact]
         public void should_mark_the_commit_as_dispatched()
         {
-            _persistence.Verify(x => x.MarkCommitAsDispatched(_commitAttempt), Times.Once());
+            A.CallTo(() => persistence.MarkCommitAsDispatched(_commit)).MustHaveHappened(Repeated.Exactly.Once);
         }
     }
 
     public class when_disposing_the_synchronous_dispatch_scheduler : SpecificationBase
     {
-        private readonly Mock<IDispatchCommits> _dispatcher = new Mock<IDispatchCommits>();
-        private readonly Mock<IPersistStreams> _persistence = new Mock<IPersistStreams>();
+        private readonly IDispatchCommits dispatcher = A.Fake<IDispatchCommits>();
+        private readonly IPersistStreams persistence = A.Fake<IPersistStreams>();
         private SynchronousDispatchScheduler _dispatchScheduler;
 
         protected override void Context()
         {
-            _dispatcher.Setup(x => x.Dispose());
-            _persistence.Setup(x => x.Dispose());
-            _dispatchScheduler = new SynchronousDispatchScheduler(_dispatcher.Object, _persistence.Object);
+            _dispatchScheduler = new SynchronousDispatchScheduler(dispatcher, persistence);
         }
 
         protected override void Because()
@@ -106,13 +100,13 @@ namespace NEventStore.DispatcherTests
         [Fact]
         public void should_dispose_the_underlying_dispatcher_exactly_once()
         {
-            _dispatcher.Verify(x => x.Dispose(), Times.Once());
+            A.CallTo(() => dispatcher.Dispose()).MustHaveHappened(Repeated.Exactly.Once);
         }
 
         [Fact]
         public void should_dispose_the_underlying_persistence_infrastructure_exactly_once()
         {
-            _dispatcher.Verify(x => x.Dispose(), Times.Once());
+            A.CallTo(() => persistence.Dispose()).MustHaveHappened(Repeated.Exactly.Once);
         }
     }
 }

--- a/src/NEventStore.Tests/NEventStore.Tests.csproj
+++ b/src/NEventStore.Tests/NEventStore.Tests.csproj
@@ -35,9 +35,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
+    <Reference Include="FakeItEasy">
+      <HintPath>..\packages\FakeItEasy.1.13.1\lib\net40\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/NEventStore.Tests/PipelineHooksAwarePersistanceDecoratorTests.cs
+++ b/src/NEventStore.Tests/PipelineHooksAwarePersistanceDecoratorTests.cs
@@ -7,7 +7,9 @@ namespace NEventStore
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using Moq;
+
+    using FakeItEasy;
+
     using NEventStore.Persistence;
     using NEventStore.Persistence.AcceptanceTests.BDD;
     using Xunit;
@@ -22,7 +24,7 @@ namespace NEventStore
         [Fact]
         public void should_dispose_the_underlying_persistence()
         {
-            persistence.Verify(x => x.Dispose(), Times.Once());
+            A.CallTo(() => persistence.Dispose()).MustHaveHappened(Repeated.Exactly.Once);
         }
     }
 
@@ -30,41 +32,43 @@ namespace NEventStore
     {
         private ICommit _commit;
         private DateTime date;
-        private Mock<IPipelineHook> hook1;
-        private Mock<IPipelineHook> hook2;
+        private IPipelineHook hook1;
+        private IPipelineHook hook2;
 
         protected override void Context()
         {
             date = DateTime.Now;
             _commit = new Commit(Bucket.Default, streamId, 1, Guid.NewGuid(), 1, DateTime.Now, new LongCheckpoint(0).Value, null, null);
 
-            hook1 = new Mock<IPipelineHook>();
-            hook1.Setup(h => h.Select(_commit)).Returns(_commit);
+            hook1 = A.Fake<IPipelineHook>();
+            A.CallTo(() => hook1.Select(_commit)).Returns(_commit);
             pipelineHooks.Add(hook1);
 
-            hook2 = new Mock<IPipelineHook>();
-            hook2.Setup(h => h.Select(_commit)).Returns(_commit);
+            hook2 = A.Fake<IPipelineHook>();
+            A.CallTo(() => hook2.Select(_commit)).Returns(_commit);
             pipelineHooks.Add(hook2);
 
-            persistence.Setup(p => p.GetFrom(Bucket.Default, date)).Returns(new List<ICommit> { _commit });
+            A.CallTo(() => persistence.GetFrom(Bucket.Default, date)).Returns(new List<ICommit> { _commit });
         }
 
         protected override void Because()
         {
+            // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
+            // Forces enumeration of commits.
             Decorator.GetFrom(date).ToList();
         }
 
         [Fact]
         public void should_call_the_underlying_persistence_to_get_events()
         {
-            persistence.Verify(x => x.GetFrom(Bucket.Default, date), Times.Once());
+            A.CallTo(() => persistence.GetFrom(Bucket.Default, date)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
         [Fact]
         public void should_pass_all_events_through_the_pipeline_hooks()
         {
-            hook1.Verify(h => h.Select(_commit), Times.Once());
-            hook2.Verify(h => h.Select(_commit), Times.Once());
+            A.CallTo(() => hook1.Select(_commit)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => hook2.Select(_commit)).MustHaveHappened(Repeated.Exactly.Once);
         }
     }
 
@@ -72,9 +76,8 @@ namespace NEventStore
     {
         private ICommit _commit;
         private DateTime end;
-        private Mock<IPipelineHook> hook1;
-        private Mock<IPipelineHook> hook2;
-
+        private IPipelineHook hook1;
+        private IPipelineHook hook2;
         private DateTime start;
 
         protected override void Context()
@@ -83,33 +86,35 @@ namespace NEventStore
             end = DateTime.Now;
             _commit = new Commit(Bucket.Default, streamId, 1, Guid.NewGuid(), 1, DateTime.Now, new LongCheckpoint(0).Value, null, null);
 
-            hook1 = new Mock<IPipelineHook>();
-            hook1.Setup(h => h.Select(_commit)).Returns(_commit);
+            hook1 = A.Fake<IPipelineHook>();
+            A.CallTo(() => hook1.Select(_commit)).Returns(_commit);
             pipelineHooks.Add(hook1);
 
-            hook2 = new Mock<IPipelineHook>();
-            hook2.Setup(h => h.Select(_commit)).Returns(_commit);
+            hook2 = A.Fake<IPipelineHook>();
+            A.CallTo(() => hook2.Select(_commit)).Returns(_commit);
             pipelineHooks.Add(hook2);
 
-            persistence.Setup(p => p.GetFromTo(Bucket.Default, start, end)).Returns(new List<ICommit> { _commit });
+            A.CallTo(() => persistence.GetFromTo(Bucket.Default, start, end)).Returns(new List<ICommit> { _commit });
         }
 
         protected override void Because()
         {
+            // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
+            // Forces enumeration of commits
             Decorator.GetFromTo(start, end).ToList();
         }
 
         [Fact]
         public void should_call_the_underlying_persistence_to_get_events()
         {
-            persistence.Verify(x => x.GetFromTo(Bucket.Default, start, end), Times.Once());
+            A.CallTo(() => persistence.GetFromTo(Bucket.Default, start, end)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
         [Fact]
         public void should_pass_all_events_through_the_pipeline_hooks()
         {
-            hook1.Verify(h => h.Select(_commit), Times.Once());
-            hook2.Verify(h => h.Select(_commit), Times.Once());
+            A.CallTo(() => hook1.Select(_commit)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => hook2.Select(_commit)).MustHaveHappened(Repeated.Exactly.Once);
         }
     }
 
@@ -130,7 +135,7 @@ namespace NEventStore
         [Fact]
         public void should_dispose_the_underlying_persistence()
         {
-            persistence.Verify(x => x.Commit(attempt), Times.Once());
+            A.CallTo(() => persistence.Commit(attempt)).MustHaveHappened(Repeated.Exactly.Once);
         }
     }
 
@@ -138,23 +143,23 @@ namespace NEventStore
     {
         private ICommit _commit;
         private DateTime date;
-        private Mock<IPipelineHook> hook1;
-        private Mock<IPipelineHook> hook2;
+        private IPipelineHook hook1;
+        private IPipelineHook hook2;
 
         protected override void Context()
         {
             date = DateTime.Now;
             _commit = new Commit(Bucket.Default, streamId, 1, Guid.NewGuid(), 1, DateTime.Now, new LongCheckpoint(0).Value, null, null);
 
-            hook1 = new Mock<IPipelineHook>();
-            hook1.Setup(h => h.Select(_commit)).Returns(_commit);
+            hook1 = A.Fake<IPipelineHook>();
+            A.CallTo(() => hook1.Select(_commit)).Returns(_commit);
             pipelineHooks.Add(hook1);
 
-            hook2 = new Mock<IPipelineHook>();
-            hook2.Setup(h => h.Select(_commit)).Returns(_commit);
+            hook2 = A.Fake<IPipelineHook>();
+            A.CallTo(() => hook2.Select(_commit)).Returns(_commit);
             pipelineHooks.Add(hook2);
 
-            persistence.Setup(p => p.GetFrom(null)).Returns(new List<ICommit> { _commit });
+            A.CallTo(() => persistence.GetFrom(null)).Returns(new List<ICommit> { _commit });
         }
 
         protected override void Because()
@@ -165,14 +170,14 @@ namespace NEventStore
         [Fact]
         public void should_call_the_underlying_persistence_to_get_events()
         {
-            persistence.Verify(x => x.GetFrom(null), Times.Once());
+            A.CallTo(() => persistence.GetFrom(null)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
         [Fact]
         public void should_pass_all_events_through_the_pipeline_hooks()
         {
-            hook1.Verify(h => h.Select(_commit), Times.Once());
-            hook2.Verify(h => h.Select(_commit), Times.Once());
+            A.CallTo(() => hook1.Select(_commit)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => hook2.Select(_commit)).MustHaveHappened(Repeated.Exactly.Once);
         }
     }
 
@@ -180,23 +185,23 @@ namespace NEventStore
     {
         private ICommit _commit;
         private DateTime date;
-        private Mock<IPipelineHook> hook1;
-        private Mock<IPipelineHook> hook2;
+        private IPipelineHook hook1;
+        private IPipelineHook hook2;
 
         protected override void Context()
         {
             date = DateTime.Now;
             _commit = new Commit(Bucket.Default, streamId, 1, Guid.NewGuid(), 1, DateTime.Now, new LongCheckpoint(0).Value, null, null);
 
-            hook1 = new Mock<IPipelineHook>();
-            hook1.Setup(h => h.Select(_commit)).Returns(_commit);
+            hook1 = A.Fake<IPipelineHook>();
+            A.CallTo(() => hook1.Select(_commit)).Returns(_commit);
             pipelineHooks.Add(hook1);
 
-            hook2 = new Mock<IPipelineHook>();
-            hook2.Setup(h => h.Select(_commit)).Returns(_commit);
+            hook2 = A.Fake<IPipelineHook>();
+            A.CallTo(() => hook2.Select(_commit)).Returns(_commit);
             pipelineHooks.Add(hook2);
 
-            persistence.Setup(p => p.GetUndispatchedCommits()).Returns(new List<ICommit> { _commit });
+            A.CallTo(() => persistence.GetUndispatchedCommits()).Returns(new List<ICommit> { _commit });
         }
 
         protected override void Because()
@@ -207,27 +212,27 @@ namespace NEventStore
         [Fact]
         public void should_call_the_underlying_persistence_to_get_events()
         {
-            persistence.Verify(x => x.GetUndispatchedCommits(), Times.Once());
+            A.CallTo(() => persistence.GetUndispatchedCommits()).MustHaveHappened(Repeated.Exactly.Once);
         }
 
         [Fact]
         public void should_pass_all_events_through_the_pipeline_hooks()
         {
-            hook1.Verify(h => h.Select(_commit), Times.Once());
-            hook2.Verify(h => h.Select(_commit), Times.Once());
+            A.CallTo(() => hook1.Select(_commit)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => hook2.Select(_commit)).MustHaveHappened(Repeated.Exactly.Once);
         }
     }
 
     public abstract class using_underlying_persistence : SpecificationBase
     {
         private PipelineHooksAwarePersistanceDecorator decorator;
-        protected readonly Mock<IPersistStreams> persistence = new Mock<IPersistStreams>();
-        protected readonly List<Mock<IPipelineHook>> pipelineHooks = new List<Mock<IPipelineHook>>();
+        protected readonly IPersistStreams persistence = A.Fake<IPersistStreams>();
+        protected readonly List<IPipelineHook> pipelineHooks = new List<IPipelineHook>();
         protected string streamId = Guid.NewGuid().ToString();
 
         public PipelineHooksAwarePersistanceDecorator Decorator
         {
-            get { return decorator ?? (decorator = new PipelineHooksAwarePersistanceDecorator(persistence.Object, pipelineHooks.Select(x => x.Object))); }
+            get { return decorator ?? (decorator = new PipelineHooksAwarePersistanceDecorator(persistence, pipelineHooks.Select(x => x))); }
             set { decorator = value; }
         }
     }

--- a/src/NEventStore.Tests/packages.config
+++ b/src/NEventStore.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.0.10827" targetFramework="net40" />
+  <package id="FakeItEasy" version="1.13.1" targetFramework="net40" />
   <package id="Rx-Core" version="2.1.30214.0" targetFramework="net40" />
   <package id="Rx-Interfaces" version="2.1.30214.0" targetFramework="net40" />
   <package id="Rx-Linq" version="2.1.30214.0" targetFramework="net40" />


### PR DESCRIPTION
...ent and AsynchronousDispatcher tests Migrated SynchronousDispatcherTests OptmisticEventStreamTest migrated to FakeItEasy Refactored OptimisticEventStoreTests to FakeItEasy Refactored PipelineHooksAwarePersistanceDecoratorTests to FakeItEasy Refactored DispatchCommitHookTests to FakeItEasy Removed Moq reference from tests project Removed my own TODOs (GH issues are opened for those issues)
