### PR TITLE
add a spec for the edge case on searching for a commit

### DIFF
--- a/src/NEventStore.Persistence.AcceptanceTests/ExtensionMethods.cs
+++ b/src/NEventStore.Persistence.AcceptanceTests/ExtensionMethods.cs
@@ -79,7 +79,7 @@ namespace NEventStore.Persistence.AcceptanceTests
 
             return new CommitAttempt(commit.BucketId,
                 commit.StreamId,
-                commit.StreamRevision + 2,
+                commit.StreamRevision + messages.Count,
                 Guid.NewGuid(),
                 commit.CommitSequence + 1,
                 commit.CommitStamp.AddSeconds(1),


### PR DESCRIPTION
Expect it to fail on Sql query:
AND (StreamRevision - Items) &lt;= @MaxStreamRevision

which should be:
AND (StreamRevision - Items) &lt; @MaxStreamRevision
