### PR TITLE
Fixes #292 [Oracle] Payload of > 32KB results in exception

### DIFF
--- a/src/NEventStore.Persistence.AcceptanceTests/PersistenceTests.cs
+++ b/src/NEventStore.Persistence.AcceptanceTests/PersistenceTests.cs
@@ -838,7 +838,8 @@ namespace NEventStore.Persistence.AcceptanceTests
         }
     }
     
-    /*public class TransactionConcern : SpecificationBase, IUseFixture<PersistenceEngineFixture>
+    /* Commented out because it's not a scenario we're supporting
+     * public class TransactionConcern : SpecificationBase, IUseFixture<PersistenceEngineFixture>
     {
         private ICommit[] _commits;
         private PersistenceEngineFixture _fixture;

--- a/src/NEventStore/Persistence/Sql/SqlDialects/OracleDbStatement.cs
+++ b/src/NEventStore/Persistence/Sql/SqlDialects/OracleDbStatement.cs
@@ -8,9 +8,13 @@ namespace NEventStore.Persistence.Sql.SqlDialects
 
     public class OracleDbStatement : CommonDbStatement
     {
+        private readonly ISqlDialect _dialect;
+
         public OracleDbStatement(ISqlDialect dialect, TransactionScope scope, IDbConnection connection, IDbTransaction transaction)
             : base(dialect, scope, connection, transaction)
-        {}
+        {
+            _dialect = dialect;
+        }
 
         public override void AddParameter(string name, object value)
         {
@@ -53,6 +57,17 @@ namespace NEventStore.Persistence.Sql.SqlDialects
                 pi.SetValue(command, true, null);
             }
             return command;
+        }
+
+        protected override void BuildParameter(IDbCommand command, string name, object value)
+        {
+            //HACK
+            if (name == _dialect.Payload)
+            {
+                command.Parameters.Add(value);
+                return;
+            }
+            base.BuildParameter(command, name, value);
         }
     }
 }

--- a/src/NEventStore/Persistence/Sql/SqlDialects/OracleNativeDialect.cs
+++ b/src/NEventStore/Persistence/Sql/SqlDialects/OracleNativeDialect.cs
@@ -129,6 +129,11 @@ namespace NEventStore.Persistence.Sql.SqlDialects
             get { return MakeOracleParameter(base.Threshold); }
         }
 
+        public override string Payload
+        {
+            get { return MakeOracleParameter(base.Payload); }
+        }
+
         private string AddOuterTrailingCommitSequence(string query)
         {
             return (query.TrimEnd(new[] {';'}) + "\r\n" + OracleNativeStatements.AddCommitSequence);

--- a/src/NEventStore/Persistence/Sql/SqlPersistenceEngine.cs
+++ b/src/NEventStore/Persistence/Sql/SqlPersistenceEngine.cs
@@ -5,11 +5,13 @@ namespace NEventStore.Persistence.Sql
     using System.Data;
     using System.Globalization;
     using System.Linq;
+    using System.Reflection;
     using System.Security.Cryptography;
     using System.Text;
     using System.Threading;
     using System.Transactions;
     using NEventStore.Logging;
+    using NEventStore.Persistence.Sql.SqlDialects;
     using NEventStore.Serialization;
 
     public class SqlPersistenceEngine : IPersistStreams
@@ -23,6 +25,8 @@ namespace NEventStore.Persistence.Sql
         private readonly ISerialize _serializer;
         private bool _disposed;
         private int _initialized;
+        private Action<IDbConnection, IDbStatement, ISerialize, CommitAttempt> _writePayload;
+        private readonly AddPayloadParamater _addPayloadParamater;
 
         public SqlPersistenceEngine(
             IConnectionFactory connectionFactory,
@@ -56,6 +60,10 @@ namespace NEventStore.Persistence.Sql
             _serializer = serializer;
             _scopeOption = scopeOption;
             _pageSize = pageSize;
+
+            _addPayloadParamater = _dialect is OracleNativeDialect
+                ? new OracleAddPayloadParamater(_dialect)
+                : new AddPayloadParamater(_dialect);
 
             Logger.Debug(Messages.UsingScope, _scopeOption.ToString());
         }
@@ -216,12 +224,12 @@ namespace NEventStore.Persistence.Sql
         {
             Logger.Debug(Messages.AddingSnapshot, snapshot.StreamId, snapshot.StreamRevision);
             string streamId = snapshot.StreamId.ToHash();
-            return ExecuteCommand(cmd =>
+            return ExecuteCommand((connection, cmd) =>
                 {
                     cmd.AddParameter(_dialect.BucketId, snapshot.BucketId);
                     cmd.AddParameter(_dialect.StreamId, streamId);
                     cmd.AddParameter(_dialect.StreamRevision, snapshot.StreamRevision);
-                    cmd.AddParameter(_dialect.Payload, _serializer.Serialize(snapshot.Payload));
+                    _addPayloadParamater.WritePayload(connection, cmd, _serializer.Serialize(snapshot.Payload));
                     return cmd.ExecuteWithoutExceptions(_dialect.AppendSnapshotToCommit);
                 }) > 0;
         }
@@ -293,30 +301,30 @@ namespace NEventStore.Persistence.Sql
         {
             Logger.Debug(Messages.AttemptingToCommit, attempt.Events.Count, attempt.StreamId, attempt.CommitSequence, attempt.BucketId);
             string streamId = attempt.StreamId.ToHash();
-            return ExecuteCommand(cmd =>
-                {
-                    cmd.AddParameter(_dialect.BucketId, attempt.BucketId);
-                    cmd.AddParameter(_dialect.StreamId, streamId);
-                    cmd.AddParameter(_dialect.StreamIdOriginal, attempt.StreamId);
-                    cmd.AddParameter(_dialect.StreamRevision, attempt.StreamRevision);
-                    cmd.AddParameter(_dialect.Items, attempt.Events.Count);
-                    cmd.AddParameter(_dialect.CommitId, attempt.CommitId);
-                    cmd.AddParameter(_dialect.CommitSequence, attempt.CommitSequence);
-                    cmd.AddParameter(_dialect.CommitStamp, attempt.CommitStamp);
-                    cmd.AddParameter(_dialect.Headers, _serializer.Serialize(attempt.Headers));
-                    cmd.AddParameter(_dialect.Payload, _serializer.Serialize(attempt.Events.ToList()));
-                    var checkpointNumber = cmd.ExecuteScalar(_dialect.PersistCommit).ToLong();
-                    return new Commit(
-                        attempt.BucketId,
-                        attempt.StreamId,
-                        attempt.StreamRevision,
-                        attempt.CommitId,
-                        attempt.CommitSequence,
-                        attempt.CommitStamp,
-                        checkpointNumber.ToString(CultureInfo.InvariantCulture),
-                        attempt.Headers,
-                        attempt.Events);
-                });
+            return ExecuteCommand((connection, cmd) =>
+            {
+                cmd.AddParameter(_dialect.BucketId, attempt.BucketId);
+                cmd.AddParameter(_dialect.StreamId, streamId);
+                cmd.AddParameter(_dialect.StreamIdOriginal, attempt.StreamId);
+                cmd.AddParameter(_dialect.StreamRevision, attempt.StreamRevision);
+                cmd.AddParameter(_dialect.Items, attempt.Events.Count);
+                cmd.AddParameter(_dialect.CommitId, attempt.CommitId);
+                cmd.AddParameter(_dialect.CommitSequence, attempt.CommitSequence);
+                cmd.AddParameter(_dialect.CommitStamp, attempt.CommitStamp);
+                cmd.AddParameter(_dialect.Headers, _serializer.Serialize(attempt.Headers));
+                _addPayloadParamater.WritePayload(connection, cmd, _serializer.Serialize(attempt.Events.ToList()));
+                var checkpointNumber = cmd.ExecuteScalar(_dialect.PersistCommit).ToLong();
+                return new Commit(
+                    attempt.BucketId,
+                    attempt.StreamId,
+                    attempt.StreamRevision,
+                    attempt.CommitId,
+                    attempt.CommitSequence,
+                    attempt.CommitStamp,
+                    checkpointNumber.ToString(CultureInfo.InvariantCulture),
+                    attempt.Headers,
+                    attempt.Events);
+            });
         }
 
         private bool DetectDuplicate(CommitAttempt attempt)
@@ -397,7 +405,12 @@ namespace NEventStore.Persistence.Sql
             throw new ObjectDisposedException(Messages.AlreadyDisposed);
         }
 
-        protected virtual T ExecuteCommand<T>(Func<IDbStatement, T> command)
+        private T ExecuteCommand<T>(Func<IDbStatement, T> command)
+        {
+            return ExecuteCommand((_, statement) => command(statement));
+        }
+
+        protected virtual T ExecuteCommand<T>(Func<IDbConnection, IDbStatement, T> command)
         {
             ThrowWhenDisposed();
 
@@ -409,7 +422,7 @@ namespace NEventStore.Persistence.Sql
                 try
                 {
                     Logger.Verbose(Messages.ExecutingCommand);
-                    T rowsAffected = command(statement);
+                    T rowsAffected = command(connection, statement);
                     Logger.Verbose(Messages.CommandExecuted, rowsAffected);
 
                     if (transaction != null)
@@ -451,6 +464,60 @@ namespace NEventStore.Persistence.Sql
         private static bool RecoverableException(Exception e)
         {
             return e is UniqueKeyViolationException || e is StorageUnavailableException;
+        }
+
+        private class AddPayloadParamater
+        {
+            private readonly ISqlDialect _dialect;
+
+            protected ISqlDialect Dialect
+            {
+                get { return _dialect; }
+            }
+
+            public AddPayloadParamater(ISqlDialect dialect)
+            {
+                _dialect = dialect;
+            }
+
+            public virtual void WritePayload(IDbConnection connection, IDbStatement cmd, byte[] payload)
+            {
+                cmd.AddParameter(_dialect.Payload, payload);
+            }
+        }
+
+        private class OracleAddPayloadParamater : AddPayloadParamater
+        {
+            private readonly Type _oracleParamaterType;
+            private readonly object _blobDbType;
+            private readonly PropertyInfo _oracleParamaterValueProperty;
+            private readonly MethodInfo _oracleBlobWriteMethod;
+            private readonly Type _oracleBlobType;
+
+            public OracleAddPayloadParamater(ISqlDialect dialect)
+                : base(dialect)
+            {
+                Assembly assembly = Assembly.Load("Oracle.ManagedDataAccess");
+                _oracleParamaterType = assembly.GetType("Oracle.ManagedDataAccess.Client.OracleParameter", true);
+                _oracleParamaterValueProperty = _oracleParamaterType.GetProperty("Value");
+                _oracleBlobType = assembly.GetType("Oracle.ManagedDataAccess.Types.OracleBlob", true);
+                _oracleBlobWriteMethod = _oracleBlobType.GetMethod("Write");
+                Type oracleParamapterType = assembly.GetType("Oracle.ManagedDataAccess.Client.OracleDbType", true);
+                FieldInfo blobField = oracleParamapterType.GetField("Blob");
+                _blobDbType = blobField.GetValue(null);
+            }
+
+            public override void WritePayload(IDbConnection connection, IDbStatement cmd, byte[] payload)
+            {
+                object payloadParam = Activator.CreateInstance(
+                    _oracleParamaterType,
+                    new[] {Dialect.Payload, _blobDbType});
+                ((OracleDbStatement) cmd).AddParameter(Dialect.Payload, payloadParam);
+                object oracleConnection = ((ConnectionScope) connection).Current;
+                object oracleBlob = Activator.CreateInstance(_oracleBlobType, new[] {oracleConnection});
+                _oracleBlobWriteMethod.Invoke(oracleBlob, new object[] { payload, 0, payload.Length });
+                _oracleParamaterValueProperty.SetValue(payloadParam, oracleBlob, null);
+            }
         }
     }
 


### PR DESCRIPTION
Because the PersistCommit oracle stament is now
in an anonymous block (to support the RETURING clause) the Payload is limited to 32KB.

In order fix this we need to use use Oracle specific concrecte types and not the ado.net / general
sql abstractions. What I did not want to do was for NEventStore to have a dependency on odp.net.managed,
nor did I want to have a seperate Oracle project and nuget packages. Instead, I am using reflection for oracle
specific operation. I _think_ the structure of Oracle.ManagedDataAccess should be stable enough
(famous last words).
