### PR TITLE
DateTime is read back wrongly on SQL server

### DIFF
--- a/src/NEventStore.Persistence.AcceptanceTests/PersistenceTests.cs
+++ b/src/NEventStore.Persistence.AcceptanceTests/PersistenceTests.cs
@@ -90,7 +90,11 @@ namespace NEventStore.Persistence.AcceptanceTests
         [Fact]
         public void should_correctly_persist_the_commit_stamp()
         {
-            _persisted.CommitStamp.Subtract(_now).ShouldBeLessThanOrEqualTo(TimeSpan.FromSeconds(1));
+            var difference = _persisted.CommitStamp.Subtract(_now);
+            difference.Days.ShouldBe(0);
+            difference.Hours.ShouldBe(0);
+            difference.Minutes.ShouldBe(0);
+            difference.ShouldBeLessThanOrEqualTo(TimeSpan.FromSeconds(1));
         }
 
         [Fact]

--- a/src/NEventStore/Persistence/Sql/ExtensionMethods.cs
+++ b/src/NEventStore/Persistence/Sql/ExtensionMethods.cs
@@ -40,7 +40,7 @@ namespace NEventStore.Persistence.Sql
         public static DateTime ToDateTime(this object value)
         {
             value = value is decimal ? (long) (decimal) value : value;
-            return value is long ? new DateTime((long) value) : ((DateTime) value).ToUniversalTime();
+            return value is long ? new DateTime((long) value) : DateTime.SpecifyKind((DateTime) value, DateTimeKind.Utc);
         }
 
         public static IDbCommand SetParameter(this IDbCommand command, string name, object value)


### PR DESCRIPTION
The commit stamp is stored as utc. When it is being read back, a ToUtc() was done. However the kind is not stored in the db, so SQL server reads this back as local time. The ToUtc will then wrongly convert the datetime. I changed this to SpecifyKind, so the time self will not be changed.
