### PR TITLE
Update Json.NET to 6.0.1

### DIFF
--- a/src/NEventStore/NEventStore.csproj
+++ b/src/NEventStore/NEventStore.csproj
@@ -254,9 +254,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.5.0.6\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/src/NEventStore/packages.config
+++ b/src/NEventStore/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net40" />
   <package id="Rx-Core" version="2.1.30214.0" targetFramework="net40" />
   <package id="Rx-Interfaces" version="2.1.30214.0" targetFramework="net40" />
   <package id="Rx-Linq" version="2.1.30214.0" targetFramework="net40" />


### PR DESCRIPTION
Json.NET 6.0.1 includes support for serializing F# discriminated union types, which I'd like to use to represent events.
