### PR TITLE
Adds typed parameter support and fixes performance problem #326

### DIFF
--- a/src/NEventStore/Persistence/Sql/ExtensionMethods.cs
+++ b/src/NEventStore/Persistence/Sql/ExtensionMethods.cs
@@ -37,11 +37,13 @@ namespace NEventStore.Persistence.Sql
                     : value is decimal ? (long) (decimal) value : Convert.ToInt32(value);
         }
 
-        public static IDbCommand SetParameter(this IDbCommand command, string name, object value)
+        public static IDbCommand SetParameter(this IDbCommand command, string name, object value, DbType? parameterType = null)
         {
             Logger.Verbose("Rebinding parameter '{0}' with value: {1}", name, value);
             var parameter = (IDataParameter) command.Parameters[name];
             parameter.Value = value;
+            if (parameterType.HasValue)
+              parameter.DbType = parameterType.Value;
             return command;
         }
     }

--- a/src/NEventStore/Persistence/Sql/IDbStatement.cs
+++ b/src/NEventStore/Persistence/Sql/IDbStatement.cs
@@ -9,7 +9,7 @@ namespace NEventStore.Persistence.Sql
     {
         int PageSize { get; set; }
 
-        void AddParameter(string name, object value);
+        void AddParameter(string name, object value, DbType? parameterType = null);
 
         int ExecuteNonQuery(string commandText);
 

--- a/src/NEventStore/Persistence/Sql/SqlDialects/OracleDbStatement.cs
+++ b/src/NEventStore/Persistence/Sql/SqlDialects/OracleDbStatement.cs
@@ -17,17 +17,17 @@ namespace NEventStore.Persistence.Sql.SqlDialects
             _dialect = dialect;
         }
 
-        public override void AddParameter(string name, object value)
+        public override void AddParameter(string name, object value, DbType? dbType = null)
         {
             name = name.Replace('@', ':');
 
             if (value is Guid)
             {
-                base.AddParameter(name, ((Guid) value).ToByteArray());
+                base.AddParameter(name, ((Guid) value).ToByteArray(), null);
             }
             else
             {
-                base.AddParameter(name, value);
+                base.AddParameter(name, value, dbType);
             }
         }
 
@@ -60,7 +60,7 @@ namespace NEventStore.Persistence.Sql.SqlDialects
             return command;
         }
 
-        protected override void BuildParameter(IDbCommand command, string name, object value)
+        protected override void BuildParameter(IDbCommand command, string name, object value, DbType? dbType)
         {
             //HACK
             if (name == _dialect.Payload && value is DbParameter)
@@ -68,7 +68,7 @@ namespace NEventStore.Persistence.Sql.SqlDialects
                 command.Parameters.Add(value);
                 return;
             }
-            base.BuildParameter(command, name, value);
+            base.BuildParameter(command, name, value, dbType);
         }
     }
 }

--- a/src/NEventStore/Persistence/Sql/SqlPersistenceEngine.cs
+++ b/src/NEventStore/Persistence/Sql/SqlPersistenceEngine.cs
@@ -99,8 +99,8 @@ namespace NEventStore.Persistence.Sql
             return ExecuteQuery(query =>
                 {
                     string statement = _dialect.GetCommitsFromStartingRevision;
-                    query.AddParameter(_dialect.BucketId, bucketId);
-                    query.AddParameter(_dialect.StreamId, streamId);
+                    query.AddParameter(_dialect.BucketId, bucketId, DbType.AnsiString);
+                    query.AddParameter(_dialect.StreamId, streamId, DbType.AnsiString);
                     query.AddParameter(_dialect.StreamRevision, minRevision);
                     query.AddParameter(_dialect.MaxStreamRevision, maxRevision);
                     query.AddParameter(_dialect.CommitSequence, 0);
@@ -123,7 +123,7 @@ namespace NEventStore.Persistence.Sql
             return ExecuteQuery(query =>
                 {
                     string statement = _dialect.GetCommitsFromInstant;
-                    query.AddParameter(_dialect.BucketId, bucketId);
+                    query.AddParameter(_dialect.BucketId, bucketId, DbType.AnsiString);
                     query.AddParameter(_dialect.CommitStamp, start);
                     return query.ExecutePagedQuery(statement, (q, r) => { })
                             .Select(x => x.GetCommit(_serializer, _dialect));
@@ -146,7 +146,7 @@ namespace NEventStore.Persistence.Sql
             return ExecuteQuery(query =>
                 {
                     string statement = _dialect.GetCommitsFromToInstant;
-                    query.AddParameter(_dialect.BucketId, bucketId);
+                    query.AddParameter(_dialect.BucketId, bucketId, DbType.AnsiString);
                     query.AddParameter(_dialect.CommitStampStart, start);
                     query.AddParameter(_dialect.CommitStampEnd, end);
                     return query.ExecutePagedQuery(statement, (q, r) => { })
@@ -196,8 +196,8 @@ namespace NEventStore.Persistence.Sql
             string streamId = _streamIdHasher.GetHash(commit.StreamId);
             ExecuteCommand(cmd =>
                 {
-                    cmd.AddParameter(_dialect.BucketId, commit.BucketId);
-                    cmd.AddParameter(_dialect.StreamId, streamId);
+                    cmd.AddParameter(_dialect.BucketId, commit.BucketId, DbType.AnsiString);
+                    cmd.AddParameter(_dialect.StreamId, streamId, DbType.AnsiString);
                     cmd.AddParameter(_dialect.CommitSequence, commit.CommitSequence);
                     return cmd.ExecuteWithoutExceptions(_dialect.MarkCommitAsDispatched);
                 });
@@ -209,11 +209,11 @@ namespace NEventStore.Persistence.Sql
             return ExecuteQuery(query =>
                 {
                     string statement = _dialect.GetStreamsRequiringSnapshots;
-                    query.AddParameter(_dialect.BucketId, bucketId);
+                    query.AddParameter(_dialect.BucketId, bucketId, DbType.AnsiString);
                     query.AddParameter(_dialect.Threshold, maxThreshold);
                     return
                         query.ExecutePagedQuery(statement,
-                            (q, s) => q.SetParameter(_dialect.StreamId, _dialect.CoalesceParameterValue(s.StreamId())))
+                            (q, s) => q.SetParameter(_dialect.StreamId, _dialect.CoalesceParameterValue(s.StreamId()), DbType.AnsiString))
                             .Select(x => x.GetStreamToSnapshot());
                 });
         }
@@ -225,8 +225,8 @@ namespace NEventStore.Persistence.Sql
             return ExecuteQuery(query =>
                 {
                     string statement = _dialect.GetSnapshot;
-                    query.AddParameter(_dialect.BucketId, bucketId);
-                    query.AddParameter(_dialect.StreamId, streamId);
+                    query.AddParameter(_dialect.BucketId, bucketId, DbType.AnsiString);
+                    query.AddParameter(_dialect.StreamId, streamId, DbType.AnsiString);
                     query.AddParameter(_dialect.StreamRevision, maxRevision);
                     return query.ExecuteWithQuery(statement).Select(x => x.GetSnapshot(_serializer));
                 }).FirstOrDefault();
@@ -238,8 +238,8 @@ namespace NEventStore.Persistence.Sql
             string streamId = _streamIdHasher.GetHash(snapshot.StreamId);
             return ExecuteCommand((connection, cmd) =>
                 {
-                    cmd.AddParameter(_dialect.BucketId, snapshot.BucketId);
-                    cmd.AddParameter(_dialect.StreamId, streamId);
+                    cmd.AddParameter(_dialect.BucketId, snapshot.BucketId, DbType.AnsiString);
+                    cmd.AddParameter(_dialect.StreamId, streamId, DbType.AnsiString);
                     cmd.AddParameter(_dialect.StreamRevision, snapshot.StreamRevision);
                     _dialect.AddPayloadParamater(_connectionFactory, connection, cmd, _serializer.Serialize(snapshot.Payload));
                     return cmd.ExecuteWithoutExceptions(_dialect.AppendSnapshotToCommit);
@@ -257,7 +257,7 @@ namespace NEventStore.Persistence.Sql
             Logger.Warn(Messages.PurgingBucket, bucketId);
             ExecuteCommand(cmd =>
                 {
-                    cmd.AddParameter(_dialect.BucketId, bucketId);
+                    cmd.AddParameter(_dialect.BucketId, bucketId, DbType.AnsiString);
                     return cmd.ExecuteNonQuery(_dialect.PurgeBucket);
                 });
         }
@@ -274,8 +274,8 @@ namespace NEventStore.Persistence.Sql
             streamId = _streamIdHasher.GetHash(streamId);
             ExecuteCommand(cmd =>
                 {
-                    cmd.AddParameter(_dialect.BucketId, bucketId);
-                    cmd.AddParameter(_dialect.StreamId, streamId);
+                    cmd.AddParameter(_dialect.BucketId, bucketId, DbType.AnsiString);
+                    cmd.AddParameter(_dialect.StreamId, streamId, DbType.AnsiString);
                     return cmd.ExecuteNonQuery(_dialect.DeleteStream);
                 });
         }
@@ -318,8 +318,8 @@ namespace NEventStore.Persistence.Sql
             string streamId = _streamIdHasher.GetHash(attempt.StreamId);
             return ExecuteCommand((connection, cmd) =>
             {
-                cmd.AddParameter(_dialect.BucketId, attempt.BucketId);
-                cmd.AddParameter(_dialect.StreamId, streamId);
+                cmd.AddParameter(_dialect.BucketId, attempt.BucketId, DbType.AnsiString);
+                cmd.AddParameter(_dialect.StreamId, streamId, DbType.AnsiString);
                 cmd.AddParameter(_dialect.StreamIdOriginal, attempt.StreamId);
                 cmd.AddParameter(_dialect.StreamRevision, attempt.StreamRevision);
                 cmd.AddParameter(_dialect.Items, attempt.Events.Count);
@@ -348,8 +348,8 @@ namespace NEventStore.Persistence.Sql
             string streamId = _streamIdHasher.GetHash(attempt.StreamId);
             return ExecuteCommand(cmd =>
                 {
-                    cmd.AddParameter(_dialect.BucketId, attempt.BucketId);
-                    cmd.AddParameter(_dialect.StreamId, streamId);
+                    cmd.AddParameter(_dialect.BucketId, attempt.BucketId, DbType.AnsiString);
+                    cmd.AddParameter(_dialect.StreamId, streamId, DbType.AnsiString);
                     cmd.AddParameter(_dialect.CommitId, attempt.CommitId);
                     cmd.AddParameter(_dialect.CommitSequence, attempt.CommitSequence);
                     object value = cmd.ExecuteScalar(_dialect.DuplicateCommit);


### PR DESCRIPTION
The @BucketId and @StreamId parameters were previously passed in as NVARCHAR values via ADO.NET, whereas the indexes are defined on VARCHAR and CHAR values. This caused (at least) SQL Server to skip the indexes, e.g., when calling OpenStream. This is now fixed by declaring the @BucketId and @StreamId parameters as "AnsiString". Fixes #326 .
