### PR TITLE
ConfigurationConnectionFactory initialization raises exception

### DIFF
--- a/src/NEventStore/Persistence/Sql/Messages.resx
+++ b/src/NEventStore/Persistence/Sql/Messages.resx
@@ -130,7 +130,7 @@
     <value>A connection could not be created for the specified named connection.</value>
   </data>
   <data name="ConfiguringConnections" xml:space="preserve">
-    <value>Configuring connections: master '{0}'; replica '{1}', shards: {2}.</value>
+    <value>Configuring connections: master '{0}'.</value>
   </data>
   <data name="OpeningMasterConnection" xml:space="preserve">
     <value>Opening master connection '{0}'</value>


### PR DESCRIPTION
ConfiguringConnections resource string defines three place holders but only one is provided. This causes exception when initializing ConfigurationConnectionFactory.
