### PR TITLE
Added typed delegate for conflict resolution and corresponding processing

### DIFF
--- a/src/NEventStore/CommonDomain/IDetectConflicts.cs
+++ b/src/NEventStore/CommonDomain/IDetectConflicts.cs
@@ -1,13 +1,36 @@
 namespace CommonDomain
 {
+	using System;
 	using System.Collections.Generic;
 
 	public interface IDetectConflicts
 	{
-		void Register<TUncommitted, TCommitted>(ConflictDelegate handler) where TUncommitted : class where TCommitted : class;
+		void Register<TUncommitted, TCommitted>(ConflictDelegate<TUncommitted, TCommitted> handler)
+			where TUncommitted : class
+			where TCommitted : class;
 
 		bool ConflictsWith(IEnumerable<object> uncommittedEvents, IEnumerable<object> committedEvents);
 	}
 
+	[Obsolete("Use ConflictDelegate<TUncommitted, TCommitted> delegate instead")]
 	public delegate bool ConflictDelegate(object uncommitted, object committed);
+
+	public delegate bool ConflictDelegate<in TUncommitted, in TCommitted>(TUncommitted uncommitted, TCommitted committed)
+		where TUncommitted : class
+		where TCommitted : class;
+
+	public static class DetectConflictsExtensions
+	{
+		/// <summary>
+		///   Provides backward compatibility for untyped ConflictDelegate users
+		/// </summary>
+		// ReSharper disable once CSharpWarnings::CS0612
+		[Obsolete("Use Register<TUncommitted, TCommitted>(ConflictDelegate<TUncommitted, TCommitted>) overload instead")]
+		public static void Register<TUncommitted, TCommitted>(this IDetectConflicts conflictDetector, ConflictDelegate handler)
+			where TUncommitted : class
+			where TCommitted : class
+		{
+			conflictDetector.Register<TUncommitted, TCommitted>((uncommitted, committed) => handler(uncommitted, committed));
+		}
+	}
 }


### PR DESCRIPTION
Previously the `IDetectConflicts.Register<TUncommitted, TCommitted>` method accepted `bool ConflictDelegate(object, object)` even though actual parameters passed to delegate where typed `TUncommitted` and `TCommitted`, forcing developers to cast them back to event types. 

This PR fixes this issue while maintaining backward compatibility through extension method (marked as obsolete to forth devs to move away from untyped code).
