### PR TITLE
Added possibility to setup ConfigurationConnectionFactory with a connectionstring instead of connectionname

### DIFF
--- a/src/NEventStore/Persistence/Sql/ConfigurationConnectionFactory.cs
+++ b/src/NEventStore/Persistence/Sql/ConfigurationConnectionFactory.cs
@@ -21,11 +21,18 @@ namespace NEventStore.Persistence.Sql
             new Dictionary<string, DbProviderFactory>();
 
         private readonly string _connectionName;
+        private readonly ConnectionStringSettings _connectionStringSettings;
 
         public ConfigurationConnectionFactory(string connectionName)
         {
             _connectionName = connectionName ?? DefaultConnectionName;
             Logger.Debug(Messages.ConfiguringConnections, _connectionName);
+        }
+
+        public ConfigurationConnectionFactory(string connectionName, string providerName, string connectionString)
+            : this(connectionName)
+        {
+            _connectionStringSettings = new ConnectionStringSettings(_connectionName, connectionString, providerName);
         }
 
         public virtual ConnectionStringSettings Settings
@@ -111,7 +118,7 @@ namespace NEventStore.Persistence.Sql
         {
             Logger.Debug(Messages.DiscoveringConnectionSettings, connectionName);
 
-            ConnectionStringSettings settings = ConfigurationManager.ConnectionStrings
+            ConnectionStringSettings settings = _connectionStringSettings ?? ConfigurationManager.ConnectionStrings
                                                                     .Cast<ConnectionStringSettings>()
                                                                     .FirstOrDefault(x => x.Name == connectionName);
 

--- a/src/NEventStore/Persistence/Sql/SqlPersistenceWireupExtensions.cs
+++ b/src/NEventStore/Persistence/Sql/SqlPersistenceWireupExtensions.cs
@@ -11,6 +11,12 @@ namespace NEventStore
             return wireup.UsingSqlPersistence(factory);
         }
 
+        public static SqlPersistenceWireup UsingSqlPersistence(this Wireup wireup, string connectionName, string providerName, string connectionString)
+        {
+            var factory = new ConfigurationConnectionFactory(connectionName, providerName, connectionString);
+            return wireup.UsingSqlPersistence(factory);
+        }
+
         public static SqlPersistenceWireup UsingSqlPersistence(this Wireup wireup, IConnectionFactory factory)
         {
             return new SqlPersistenceWireup(wireup, factory);


### PR DESCRIPTION
Currently only the connectionname can be specified when setting up the connection to the database. This forces users of NEventStore to store connection strings in connection string section in the .config file. To enable users to retrieve connection strings from other sources I added an extra option on the ConfigurationConnectionFactory which enables to set the connection string manually.
