### PR TITLE
Add BucketId to IEventStream

### DIFF
--- a/src/NEventStore/IEventStream.cs
+++ b/src/NEventStore/IEventStream.cs
@@ -13,6 +13,10 @@ namespace NEventStore
     public interface IEventStream : IDisposable
     {
         /// <summary>
+        ///     Gets the value which identifies bucket to which the the stream belongs.
+        /// </summary>
+        string BucketId { get; }
+        /// <summary>
         ///     Gets the value which uniquely identifies the stream to which the stream belongs.
         /// </summary>
         string StreamId { get; }


### PR DESCRIPTION
Fixes #381 

optimistic event stream implementation already had BucketId so this was just a matter of adding the definition to IEventStream.