### PR TITLE
Allow clients to override the default IRouteEvents in AggregateBase

### DIFF
--- a/src/NEventStore/CommonDomain/Core/AggregateBase.cs
+++ b/src/NEventStore/CommonDomain/Core/AggregateBase.cs
@@ -3,8 +3,9 @@ namespace CommonDomain.Core
 	using System;
 	using System.Collections;
 	using System.Collections.Generic;
+	using NEventStore;
 
-	public abstract class AggregateBase : IAggregate, IEquatable<IAggregate>
+    public abstract class AggregateBase : IAggregate, IEquatable<IAggregate>
 	{
 		private readonly ICollection<object> uncommittedEvents = new LinkedList<object>();
 
@@ -29,7 +30,7 @@ namespace CommonDomain.Core
 		{
 			get
 			{
-				return this.registeredRoutes ?? (this.registeredRoutes = new ConventionEventRouter(true, this));
+				return this.registeredRoutes ?? (this.registeredRoutes = ConventionEventRouterBuilder.Build(this));
 			}
 			set
 			{

--- a/src/NEventStore/ConventionEventRouterBuilder.cs
+++ b/src/NEventStore/ConventionEventRouterBuilder.cs
@@ -1,0 +1,11 @@
+﻿namespace NEventStore
+{
+    using System;
+    using CommonDomain;
+    using CommonDomain.Core;
+
+    public static class ConventionEventRouterBuilder
+    {
+        public static Func<IAggregate, IRouteEvents> Build = (aggregate) => new ConventionEventRouter(true, aggregate);
+    }
+}

--- a/src/NEventStore/NEventStore.csproj
+++ b/src/NEventStore/NEventStore.csproj
@@ -112,6 +112,7 @@
     <Compile Include="ICheckpoint.cs" />
     <Compile Include="ICommit.cs" />
     <Compile Include="ImmutableCollection.cs" />
+    <Compile Include="ConventionEventRouterBuilder.cs" />
     <Compile Include="LongCheckpoint.cs" />
     <Compile Include="ISnapshot.cs" />
     <Compile Include="LoggingWireupExtensions.cs" />


### PR DESCRIPTION
Makes it possible for Aggregates to have a diffrent ConventionEventRouter.
So we don't have to create a bunch of empty Apply() methods.