### PR TITLE
Fix for issue #420

### DIFF
--- a/src/NEventStore/OptimisticPipelineHook.cs
+++ b/src/NEventStore/OptimisticPipelineHook.cs
@@ -54,7 +54,7 @@ namespace NEventStore
                 throw new ConcurrencyException();
             }
 
-            if (head.StreamRevision >= attempt.StreamRevision)
+            if (head.StreamRevision >= attempt.StreamRevision - attempt.Events.Count)
             {
                 throw new ConcurrencyException();
             }


### PR DESCRIPTION
Fixes an issue where the event stream revision
number can be corrupted by obtaining a stream from
the middle of a commit with multiple events, and
then adding several new events.