### PR TITLE
Improved logger and little log level refactoring

### DIFF
--- a/src/NEventStore.Example/MainProgram.cs
+++ b/src/NEventStore.Example/MainProgram.cs
@@ -3,6 +3,7 @@ namespace NEventStore.Example
     using System;
     using System.Transactions;
     using NEventStore;
+    using Logging;
 
     internal static class MainProgram
 	{
@@ -15,7 +16,9 @@ namespace NEventStore.Example
 
 		private static void Main()
 		{
-			using (var scope = new TransactionScope())
+            Console.WindowWidth = Console.LargestWindowWidth - 20;
+
+            using (var scope = new TransactionScope())
 			using (store = WireupEventStore())
 			{
 				OpenOrCreateStream();
@@ -32,7 +35,8 @@ namespace NEventStore.Example
 		private static IStoreEvents WireupEventStore()
 		{
 			 return Wireup.Init()
-				.LogToOutputWindow()
+				.LogToOutputWindow(LogLevel.Info)
+                .LogToConsoleWindow(LogLevel.Info)
 				.UsingInMemoryPersistence()
 					.InitializeStorageEngine()
 					.TrackPerformanceInstance("example")

--- a/src/NEventStore/Logging/ConsoleWindowLogger.cs
+++ b/src/NEventStore/Logging/ConsoleWindowLogger.cs
@@ -2,43 +2,45 @@ namespace NEventStore.Logging
 {
     using System;
 
-    public class ConsoleWindowLogger : ILog
+    public class ConsoleWindowLogger : NEventStoreBaseLogger
     {
         private static readonly object Sync = new object();
         private readonly ConsoleColor _originalColor = Console.ForegroundColor;
         private readonly Type _typeToLog;
 
-        public ConsoleWindowLogger(Type typeToLog)
+        public int MyProperty { get; set; }
+
+        public ConsoleWindowLogger(Type typeToLog, LogLevel logLevel = LogLevel.Info) : base (logLevel)
         {
             _typeToLog = typeToLog;
         }
 
-        public virtual void Verbose(string message, params object[] values)
+        public override void OnVerbose(string message, params object[] values)
         {
             Log(ConsoleColor.DarkGreen, message, values);
         }
 
-        public virtual void Debug(string message, params object[] values)
+        public override void OnDebug(string message, params object[] values)
         {
             Log(ConsoleColor.Green, message, values);
         }
 
-        public virtual void Info(string message, params object[] values)
+        public override void OnInfo(string message, params object[] values)
         {
             Log(ConsoleColor.White, message, values);
         }
 
-        public virtual void Warn(string message, params object[] values)
+        public override void OnWarn(string message, params object[] values)
         {
             Log(ConsoleColor.Yellow, message, values);
         }
 
-        public virtual void Error(string message, params object[] values)
+        public override void OnError(string message, params object[] values)
         {
             Log(ConsoleColor.DarkRed, message, values);
         }
 
-        public virtual void Fatal(string message, params object[] values)
+        public override void OnFatal(string message, params object[] values)
         {
             Log(ConsoleColor.Red, message, values);
         }

--- a/src/NEventStore/Logging/ILog.cs
+++ b/src/NEventStore/Logging/ILog.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace NEventStore.Logging
 {
     /// <summary>
@@ -8,6 +10,26 @@ namespace NEventStore.Logging
     /// </remarks>
     public interface ILog
     {
+        /// <summary>
+        /// Is true if the logger has verbose level enabled
+        /// </summary>
+        bool IsVerboseEnabled { get; }
+
+        /// <summary>
+        /// Is true if the logger has debug level enabled
+        /// </summary>
+        bool IsDebugEnabled { get; }
+
+        /// <summary>
+        /// Is true if the logger has debug level enabled
+        /// </summary>
+        bool IsInfoEnabled { get; }
+
+        /// <summary>
+        /// Level of the logger
+        /// </summary>
+        LogLevel LogLevel { get; }
+
         /// <summary>
         ///     Logs the most detailed level of diagnostic information.
         /// </summary>
@@ -49,5 +71,95 @@ namespace NEventStore.Logging
         /// <param name="message">The diagnostic message to be logged.</param>
         /// <param name="values">All parameter to be formatted into the message, if any.</param>
         void Fatal(string message, params object[] values);
+    }
+
+    public abstract class NEventStoreBaseLogger : ILog
+    {
+
+        public LogLevel LogLevel { get; private set; }
+
+
+        public NEventStoreBaseLogger(LogLevel logLevel)
+        {
+            LogLevel = logLevel;
+        }
+
+        public bool IsVerboseEnabled
+        {
+            get
+            {
+                return LogLevel <= LogLevel.Verbose;
+            }
+        }
+
+        public bool IsDebugEnabled
+        {
+            get
+            {
+                return LogLevel <= LogLevel.Debug;
+            }
+        }
+
+        public bool IsInfoEnabled
+        {
+            get
+            {
+                return LogLevel <= LogLevel.Info;
+            }
+        }
+
+
+        public void Verbose(string message, params object[] values)
+        {
+            if (IsVerboseEnabled) OnVerbose(message, values);
+        }
+
+        public void Debug(string message, params object[] values)
+        {
+            if (IsDebugEnabled) OnDebug(message, values);
+        }
+
+        public void Info(string message, params object[] values)
+        {
+            if (IsInfoEnabled) OnInfo(message, values);
+        }
+
+        public void Warn(string message, params object[] values)
+        {
+            OnWarn(message, values);
+        }
+
+        public void Error(string message, params object[] values)
+        {
+            OnError(message, values);
+        }
+
+        public void Fatal(string message, params object[] values)
+        {
+            OnFatal(message, values);
+        }
+
+        public abstract void OnDebug(string message, params object[] values);
+
+        public abstract void OnError(string message, params object[] values);
+
+        public abstract void OnFatal(string message, params object[] values);
+
+        public abstract void OnInfo(string message, params object[] values);
+
+        public abstract void OnVerbose(string message, params object[] values);
+
+        public abstract void OnWarn(string message, params object[] values);
+
+    }
+
+    public enum LogLevel
+    {
+        Verbose = 0,
+        Debug = 1,
+        Info = 2,
+        Warn = 3,
+        Error = 4,
+        Fatal = 5
     }
 }

--- a/src/NEventStore/Logging/LogFactory.cs
+++ b/src/NEventStore/Logging/LogFactory.cs
@@ -23,6 +23,38 @@ namespace NEventStore.Logging
 
         private class NullLogger : ILog
         {
+            public bool IsVerboseEnabled
+            {
+                get
+                {
+                    return false;
+                }
+            }
+
+            public bool IsDebugEnabled
+            {
+                get
+                {
+                    return false;
+                }
+            }
+
+            public bool IsInfoEnabled
+            {
+                get
+                {
+                    return false;
+                }
+            }
+
+            public LogLevel LogLevel
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
             public void Verbose(string message, params object[] values)
             {}
 

--- a/src/NEventStore/Logging/LogFactory.cs
+++ b/src/NEventStore/Logging/LogFactory.cs
@@ -51,7 +51,7 @@ namespace NEventStore.Logging
             {
                 get
                 {
-                    throw new NotImplementedException();
+                    return LogLevel.Fatal;
                 }
             }
 

--- a/src/NEventStore/Logging/OutputWindowLogger.cs
+++ b/src/NEventStore/Logging/OutputWindowLogger.cs
@@ -3,42 +3,42 @@ namespace NEventStore.Logging
     using System;
     using System.Diagnostics;
 
-    public class OutputWindowLogger : ILog
+    public class OutputWindowLogger : NEventStoreBaseLogger
     {
         private static readonly object Sync = new object();
         private readonly Type _typeToLog;
 
-        public OutputWindowLogger(Type typeToLog)
+        public OutputWindowLogger(Type typeToLog, LogLevel logLevel = LogLevel.Info) : base(logLevel)
         {
             _typeToLog = typeToLog;
         }
 
-        public virtual void Verbose(string message, params object[] values)
+        public override void OnVerbose(string message, params object[] values)
         {
             DebugWindow("Verbose", message, values);
         }
 
-        public virtual void Debug(string message, params object[] values)
+        public override void OnDebug(string message, params object[] values)
         {
             DebugWindow("Debug", message, values);
         }
 
-        public virtual void Info(string message, params object[] values)
+        public override void OnInfo(string message, params object[] values)
         {
             TraceWindow("Info", message, values);
         }
 
-        public virtual void Warn(string message, params object[] values)
+        public override void OnWarn(string message, params object[] values)
         {
             TraceWindow("Warn", message, values);
         }
 
-        public virtual void Error(string message, params object[] values)
+        public override void OnError(string message, params object[] values)
         {
             TraceWindow("Error", message, values);
         }
 
-        public virtual void Fatal(string message, params object[] values)
+        public override void OnFatal(string message, params object[] values)
         {
             TraceWindow("Fatal", message, values);
         }

--- a/src/NEventStore/LoggingWireupExtensions.cs
+++ b/src/NEventStore/LoggingWireupExtensions.cs
@@ -5,14 +5,14 @@ namespace NEventStore
 
     public static class LoggingWireupExtensions
     {
-        public static Wireup LogToConsoleWindow(this Wireup wireup)
+        public static Wireup LogToConsoleWindow(this Wireup wireup, LogLevel logLevel = LogLevel.Info)
         {
-            return wireup.LogTo(type => new ConsoleWindowLogger(type));
+            return wireup.LogTo(type => new ConsoleWindowLogger(type, logLevel));
         }
 
-        public static Wireup LogToOutputWindow(this Wireup wireup)
+        public static Wireup LogToOutputWindow(this Wireup wireup, LogLevel logLevel = LogLevel.Info)
         {
-            return wireup.LogTo(type => new OutputWindowLogger(type));
+            return wireup.LogTo(type => new OutputWindowLogger(type, logLevel));
         }
 
         public static Wireup LogTo(this Wireup wireup, Func<Type, ILog> logger)

--- a/src/NEventStore/Messages.Designer.cs
+++ b/src/NEventStore/Messages.Designer.cs
@@ -124,6 +124,24 @@ namespace NEventStore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Head CommitSequence [{0}] greater or equal than Attempt CommitSequence [{1}] - StreamId {2} - StreamRevision {3} - Events Count {4}.
+        /// </summary>
+        internal static string ConcurrencyExceptionCommitSequence {
+            get {
+                return ResourceManager.GetString("ConcurrencyExceptionCommitSequence", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Head StreamRevision [{0}] greater or equal than Attempt StreamRevision [{1}] - StreamId {2} - StreamRevision {3} - Events Count {4}.
+        /// </summary>
+        internal static string ConcurrencyExceptionStreamRevision {
+            get {
+                return ResourceManager.GetString("ConcurrencyExceptionStreamRevision", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Configuring serializer to compress the serialized payload..
         /// </summary>
         internal static string ConfiguringCompression {
@@ -192,6 +210,15 @@ namespace NEventStore {
         internal static string DialectSpecified {
             get {
                 return ResourceManager.GetString("DialectSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Duplicate commit id {0}..
+        /// </summary>
+        internal static string DuplicateCommitIdException {
+            get {
+                return ResourceManager.GetString("DuplicateCommitIdException", resourceCulture);
             }
         }
         
@@ -295,11 +322,38 @@ namespace NEventStore {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Head CommitSequence [{0}] lesser than Attempt CommitSequence - 1 [{1}] - StreamId {2} - StreamRevision {3} - Events Count {4}.
+        /// </summary>
+        internal static string StorageExceptionCommitSequence {
+            get {
+                return ResourceManager.GetString("StorageExceptionCommitSequence", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stream EOF: head.StreamRevision [{0}] &lt; attempt.StreamRevision [{1}] - attempt.Events.Count [{2}] - StreamId {3} - StreamRevision {4} .
+        /// </summary>
+        internal static string StorageExceptionEndOfStream {
+            get {
+                return ResourceManager.GetString("StorageExceptionEndOfStream", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Registering stream ID hasher of type &apos;{0}&apos;.
         /// </summary>
         internal static string StreamIdHasherSpecified {
             get {
                 return ResourceManager.GetString("StreamIdHasherSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stream not found: StreamId {0} bucket {1}..
+        /// </summary>
+        internal static string StreamNotFoundException {
+            get {
+                return ResourceManager.GetString("StreamNotFoundException", resourceCulture);
             }
         }
         

--- a/src/NEventStore/Messages.resx
+++ b/src/NEventStore/Messages.resx
@@ -210,4 +210,22 @@
   <data name="StreamIdHasherSpecified" xml:space="preserve">
     <value>Registering stream ID hasher of type '{0}'</value>
   </data>
+  <data name="ConcurrencyExceptionCommitSequence" xml:space="preserve">
+    <value>Head CommitSequence [{0}] greater or equal than Attempt CommitSequence [{1}] - StreamId {2} - StreamRevision {3} - Events Count {4}</value>
+  </data>
+  <data name="ConcurrencyExceptionStreamRevision" xml:space="preserve">
+    <value>Head StreamRevision [{0}] greater or equal than Attempt StreamRevision [{1}] - StreamId {2} - StreamRevision {3} - Events Count {4}</value>
+  </data>
+  <data name="DuplicateCommitIdException" xml:space="preserve">
+    <value>Duplicate commit id {0}.</value>
+  </data>
+  <data name="StorageExceptionCommitSequence" xml:space="preserve">
+    <value>Head CommitSequence [{0}] lesser than Attempt CommitSequence - 1 [{1}] - StreamId {2} - StreamRevision {3} - Events Count {4}</value>
+  </data>
+  <data name="StorageExceptionEndOfStream" xml:space="preserve">
+    <value>Stream EOF: head.StreamRevision [{0}] &lt; attempt.StreamRevision [{1}] - attempt.Events.Count [{2}] - StreamId {3} - StreamRevision {4} </value>
+  </data>
+  <data name="StreamNotFoundException" xml:space="preserve">
+    <value>Stream not found: StreamId {0} bucket {1}.</value>
+  </data>
 </root>

--- a/src/NEventStore/OptimisticEventStore.cs
+++ b/src/NEventStore/OptimisticEventStore.cs
@@ -32,7 +32,7 @@ namespace NEventStore
             Guard.NotNull(() => attempt, attempt);
             foreach (var hook in _pipelineHooks)
             {
-                Logger.Debug(Resources.InvokingPreCommitHooks, attempt.CommitId, hook.GetType());
+                Logger.Verbose(Resources.InvokingPreCommitHooks, attempt.CommitId, hook.GetType());
                 if (hook.PreCommit(attempt))
                 {
                     continue;
@@ -42,12 +42,12 @@ namespace NEventStore
                 return null;
             }
 
-            Logger.Info(Resources.CommittingAttempt, attempt.CommitId, attempt.Events.Count);
+            Logger.Verbose(Resources.CommittingAttempt, attempt.CommitId, attempt.Events == null ? 0 : attempt.Events.Count);
             ICommit commit = _persistence.Commit(attempt);
 
             foreach (var hook in _pipelineHooks)
             {
-                Logger.Debug(Resources.InvokingPostCommitPipelineHooks, attempt.CommitId, hook.GetType());
+                Logger.Verbose(Resources.InvokingPostCommitPipelineHooks, attempt.CommitId, hook.GetType());
                 hook.PostCommit(commit);
             }
             return commit;
@@ -61,7 +61,7 @@ namespace NEventStore
 
         public virtual IEventStream CreateStream(string bucketId, string streamId)
         {
-            Logger.Info(Resources.CreatingStream, streamId, bucketId);
+            Logger.Debug(Resources.CreatingStream, streamId, bucketId);
             return new OptimisticEventStream(bucketId, streamId, this);
         }
 
@@ -69,7 +69,7 @@ namespace NEventStore
         {
             maxRevision = maxRevision <= 0 ? int.MaxValue : maxRevision;
 
-            Logger.Debug(Resources.OpeningStreamAtRevision, streamId, bucketId, minRevision, maxRevision);
+            Logger.Verbose(Resources.OpeningStreamAtRevision, streamId, bucketId, minRevision, maxRevision);
             return new OptimisticEventStream(bucketId, streamId, this, minRevision, maxRevision);
         }
 
@@ -80,7 +80,7 @@ namespace NEventStore
                 throw new ArgumentNullException("snapshot");
             }
 
-            Logger.Debug(Resources.OpeningStreamWithSnapshot, snapshot.StreamId, snapshot.StreamRevision, maxRevision);
+            Logger.Verbose(Resources.OpeningStreamWithSnapshot, snapshot.StreamId, snapshot.StreamRevision, maxRevision);
             maxRevision = maxRevision <= 0 ? int.MaxValue : maxRevision;
             return new OptimisticEventStream(snapshot, this, maxRevision);
         }

--- a/src/NEventStore/OptimisticEventStream.cs
+++ b/src/NEventStore/OptimisticEventStream.cs
@@ -78,13 +78,13 @@ namespace NEventStore
                 return;
             }
 
-            Logger.Debug(Resources.AppendingUncommittedToStream, StreamId);
+            Logger.Verbose(Resources.AppendingUncommittedToStream, uncommittedEvent.Body.GetType(), StreamId);
             _events.Add(uncommittedEvent);
         }
 
         public void CommitChanges(Guid commitId)
         {
-            Logger.Debug(Resources.AttemptingToCommitChanges, StreamId);
+            Logger.Verbose(Resources.AttemptingToCommitChanges, StreamId);
 
             if (_identifiers.Contains(commitId))
             {
@@ -112,7 +112,7 @@ namespace NEventStore
 
         public void ClearChanges()
         {
-            Logger.Debug(Resources.ClearingUncommittedChanges, StreamId);
+            Logger.Verbose(Resources.ClearingUncommittedChanges, StreamId);
             _events.Clear();
             _uncommittedHeaders.Clear();
         }
@@ -177,7 +177,7 @@ namespace NEventStore
                 return true;
             }
 
-            Logger.Warn(Resources.NoChangesToCommit, StreamId);
+            Logger.Info(Resources.NoChangesToCommit, StreamId);
             return false;
         }
 
@@ -185,7 +185,7 @@ namespace NEventStore
         {
             CommitAttempt attempt = BuildCommitAttempt(commitId);
 
-            Logger.Debug(Resources.PersistingCommit, commitId, StreamId);
+            Logger.Debug(Resources.PersistingCommit, commitId, StreamId, attempt.Events == null ? 0 : attempt.Events.Count);
             ICommit commit = _persistence.Commit(attempt);
 
             PopulateStream(StreamRevision + 1, attempt.StreamRevision, new[] { commit });
@@ -194,7 +194,7 @@ namespace NEventStore
 
         private CommitAttempt BuildCommitAttempt(Guid commitId)
         {
-            Logger.Debug(Resources.BuildingCommitAttempt, commitId, StreamId);
+            Logger.Verbose(Resources.BuildingCommitAttempt, commitId, StreamId);
             return new CommitAttempt(
                 BucketId,
                 StreamId,

--- a/src/NEventStore/OptimisticEventStream.cs
+++ b/src/NEventStore/OptimisticEventStream.cs
@@ -34,7 +34,7 @@ namespace NEventStore
 
             if (minRevision > 0 && _committed.Count == 0)
             {
-                throw new StreamNotFoundException();
+                throw new StreamNotFoundException(String.Format(Messages.StreamNotFoundException, streamId, BucketId));
             }
         }
 
@@ -88,7 +88,7 @@ namespace NEventStore
 
             if (_identifiers.Contains(commitId))
             {
-                throw new DuplicateCommitException();
+                throw new DuplicateCommitException(String.Format(Messages.DuplicateCommitIdException, commitId));
             }
 
             if (!HasChanges())

--- a/src/NEventStore/OptimisticPipelineHook.cs
+++ b/src/NEventStore/OptimisticPipelineHook.cs
@@ -51,22 +51,50 @@ namespace NEventStore
 
             if (head.CommitSequence >= attempt.CommitSequence)
             {
-                throw new ConcurrencyException();
+                throw new ConcurrencyException(String.Format(
+                    Messages.ConcurrencyExceptionCommitSequence,
+                    head.CommitSequence,
+                    attempt.CommitSequence,
+                    attempt.StreamId,
+                    attempt.StreamRevision,
+                    attempt.Events.Count
+                ));
             }
 
             if (head.StreamRevision >= attempt.StreamRevision)
             {
-                throw new ConcurrencyException();
+                throw new ConcurrencyException(String.Format(
+                    Messages.ConcurrencyExceptionStreamRevision,
+                    head.StreamRevision,
+                    attempt.StreamRevision,
+                    attempt.StreamId,
+                    attempt.StreamRevision,
+                    attempt.Events.Count
+                ));
             }
 
             if (head.CommitSequence < attempt.CommitSequence - 1)
             {
-                throw new StorageException(); // beyond the end of the stream
+                throw new StorageException(String.Format(
+                     Messages.StorageExceptionCommitSequence,
+                     head.CommitSequence,
+                     attempt.CommitSequence,
+                     attempt.StreamId,
+                     attempt.StreamRevision,
+                     attempt.Events.Count
+                 )); // beyond the end of the stream
             }
 
             if (head.StreamRevision < attempt.StreamRevision - attempt.Events.Count)
             {
-                throw new StorageException(); // beyond the end of the stream
+                throw new StorageException(String.Format(
+                     Messages.StorageExceptionEndOfStream,
+                     head.StreamRevision,
+                     attempt.StreamRevision,
+                     attempt.Events.Count,
+                     attempt.StreamId,
+                     attempt.StreamRevision
+                 )); // beyond the end of the stream
             }
 
             Logger.Verbose(Resources.NoConflicts, attempt.StreamId);

--- a/src/NEventStore/OptimisticPipelineHook.cs
+++ b/src/NEventStore/OptimisticPipelineHook.cs
@@ -41,7 +41,7 @@ namespace NEventStore
 
         public override bool PreCommit(CommitAttempt attempt)
         {
-            Logger.Debug(Resources.OptimisticConcurrencyCheck, attempt.StreamId);
+            Logger.Verbose(Resources.OptimisticConcurrencyCheck, attempt.StreamId);
 
             ICommit head = GetStreamHead(GetHeadKey(attempt));
             if (head == null)
@@ -69,7 +69,7 @@ namespace NEventStore
                 throw new StorageException(); // beyond the end of the stream
             }
 
-            Logger.Debug(Resources.NoConflicts, attempt.StreamId);
+            Logger.Verbose(Resources.NoConflicts, attempt.StreamId);
             return true;
         }
 

--- a/src/NEventStore/PersistenceWireup.cs
+++ b/src/NEventStore/PersistenceWireup.cs
@@ -22,7 +22,7 @@ namespace NEventStore
 
         public virtual PersistenceWireup WithPersistence(IPersistStreams instance)
         {
-            Logger.Debug(Messages.RegisteringPersistenceEngine, instance.GetType());
+            Logger.Info(Messages.RegisteringPersistenceEngine, instance.GetType());
             With(instance);
             return this;
         }
@@ -34,7 +34,7 @@ namespace NEventStore
 
         public virtual PersistenceWireup InitializeStorageEngine()
         {
-            Logger.Debug(Messages.ConfiguringEngineInitialization);
+            Logger.Info(Messages.ConfiguringEngineInitialization);
             _initialize = true;
             return this;
         }
@@ -46,7 +46,7 @@ namespace NEventStore
                 throw new ArgumentNullException("instanceName", Messages.InstanceCannotBeNull);
             }
 
-            Logger.Debug(Messages.ConfiguringEnginePerformanceTracking);
+            Logger.Info(Messages.ConfiguringEnginePerformanceTracking);
             _tracking = true;
             _trackingInstanceName = instanceName;
             return this;
@@ -54,14 +54,14 @@ namespace NEventStore
 
         public virtual PersistenceWireup EnlistInAmbientTransaction()
         {
-            Logger.Debug(Messages.ConfiguringEngineEnlistment);
+            Logger.Info(Messages.ConfiguringEngineEnlistment);
             Container.Register(TransactionScopeOption.Required);
             return this;
         }
 
         public override IStoreEvents Build()
         {
-            Logger.Debug(Messages.BuildingEngine);
+            Logger.Info(Messages.BuildingEngine);
             var engine = Container.Resolve<IPersistStreams>();
 
             if (_initialize)

--- a/src/NEventStore/PersistenceWireupExtensions.cs
+++ b/src/NEventStore/PersistenceWireupExtensions.cs
@@ -1,12 +1,16 @@
 namespace NEventStore
 {
+    using Logging;
     using NEventStore.Persistence;
     using NEventStore.Persistence.InMemory;
 
     public static class PersistenceWireupExtensions
     {
+        private static readonly ILog Logger = LogFactory.BuildLogger(typeof(OptimisticPipelineHook));
+
         public static PersistenceWireup UsingInMemoryPersistence(this Wireup wireup)
         {
+            Logger.Info(Resources.WireupSetPersistenceEngine, "InMemoryPersistenceEngine");
             wireup.With<IPersistStreams>(new InMemoryPersistenceEngine());
 
             return new PersistenceWireup(wireup);

--- a/src/NEventStore/Resources.Designer.cs
+++ b/src/NEventStore/Resources.Designer.cs
@@ -61,7 +61,7 @@ namespace NEventStore {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Adding commit &apos;{0} with {1} events to stream &apos;{2}&apos;..
+        ///   Looks up a localized string similar to Adding commit &apos;{0}&apos; with {1} events to stream &apos;{2}&apos;..
         /// </summary>
         internal static string AddingCommitsToStream {
             get {
@@ -88,7 +88,7 @@ namespace NEventStore {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Appending uncommitted event to stream &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Appending uncommitted event &apos;{0}&apos; to stream &apos;{1}&apos;.
         /// </summary>
         internal static string AppendingUncommittedToStream {
             get {
@@ -376,7 +376,7 @@ namespace NEventStore {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Pushing attempt &apos;{0}&apos; on stream &apos;{1}&apos; to the underlying store..
+        ///   Looks up a localized string similar to Pushing attempt &apos;{0}&apos; on stream &apos;{1}&apos; with &apos;{2}&apos; events to the underlying store..
         /// </summary>
         internal static string PersistingCommit {
             get {
@@ -471,6 +471,33 @@ namespace NEventStore {
         internal static string UpdatingStreamHead {
             get {
                 return ResourceManager.GetString("UpdatingStreamHead", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hook into pipeline with hooks: {0}.
+        /// </summary>
+        internal static string WireupHookIntoPipeline {
+            get {
+                return ResourceManager.GetString("WireupHookIntoPipeline", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Configured Persistence Engine: {0}.
+        /// </summary>
+        internal static string WireupSetPersistenceEngine {
+            get {
+                return ResourceManager.GetString("WireupSetPersistenceEngine", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Configured serializer: {0}.
+        /// </summary>
+        internal static string WireupSetSerializer {
+            get {
+                return ResourceManager.GetString("WireupSetSerializer", resourceCulture);
             }
         }
     }

--- a/src/NEventStore/Resources.resx
+++ b/src/NEventStore/Resources.resx
@@ -211,7 +211,7 @@
     <value>Pushing commit '{0}' to post-commit hook of type '{1}'.</value>
   </data>
   <data name="AddingCommitsToStream" xml:space="preserve">
-    <value>Adding commit '{0} with {1} events to stream '{2}'.</value>
+    <value>Adding commit '{0}' with {1} events to stream '{2}'.</value>
   </data>
   <data name="IgnoringBeyondRevision" xml:space="preserve">
     <value>Ignoring some events on commit '{0}' of stream '{1}' because they go beyond revision {2}.</value>
@@ -220,7 +220,7 @@
     <value>Ignoring some events on commit '{0}' of stream '{1}' because they starting before revision {2}.</value>
   </data>
   <data name="AppendingUncommittedToStream" xml:space="preserve">
-    <value>Appending uncommitted event to stream '{0}'</value>
+    <value>Appending uncommitted event '{0}' to stream '{1}'</value>
   </data>
   <data name="AttemptingToCommitChanges" xml:space="preserve">
     <value>Attempting to commit all changes on stream '{0}' to the underlying store.</value>
@@ -232,7 +232,7 @@
     <value>The underlying stream '{0}' has changed since the last known commit, refreshing the stream.</value>
   </data>
   <data name="PersistingCommit" xml:space="preserve">
-    <value>Pushing attempt '{0}' on stream '{1}' to the underlying store.</value>
+    <value>Pushing attempt '{0}' on stream '{1}' with '{2}' events to the underlying store.</value>
   </data>
   <data name="BuildingCommitAttempt" xml:space="preserve">
     <value>Building a commit attempt '{0}' on stream '{1}'.</value>
@@ -254,5 +254,14 @@
   </data>
   <data name="DeletingStream" xml:space="preserve">
     <value>Deleting stream '{0}' from bucket '{1}'.</value>
+  </data>
+  <data name="WireupHookIntoPipeline" xml:space="preserve">
+    <value>Hook into pipeline with hooks: {0}</value>
+  </data>
+  <data name="WireupSetPersistenceEngine" xml:space="preserve">
+    <value>Configured Persistence Engine: {0}</value>
+  </data>
+  <data name="WireupSetSerializer" xml:space="preserve">
+    <value>Configured serializer: {0}</value>
   </data>
 </root>

--- a/src/NEventStore/SerializationWireup.cs
+++ b/src/NEventStore/SerializationWireup.cs
@@ -18,7 +18,7 @@ namespace NEventStore
             Logger.Debug(Messages.ConfiguringCompression);
             var wrapped = Container.Resolve<ISerialize>();
 
-            Logger.Debug(Messages.WrappingSerializerGZip, wrapped.GetType());
+            Logger.Info(Messages.WrappingSerializerGZip, wrapped.GetType());
             Container.Register<ISerialize>(new GzipSerializer(wrapped));
             return this;
         }
@@ -28,7 +28,7 @@ namespace NEventStore
             Logger.Debug(Messages.ConfiguringEncryption);
             var wrapped = Container.Resolve<ISerialize>();
 
-            Logger.Debug(Messages.WrappingSerializerEncryption, wrapped.GetType());
+            Logger.Info(Messages.WrappingSerializerEncryption, wrapped.GetType());
             Container.Register<ISerialize>(new RijndaelSerializer(wrapped, encryptionKey));
             return this;
         }

--- a/src/NEventStore/SerializationWireupExtensions.cs
+++ b/src/NEventStore/SerializationWireupExtensions.cs
@@ -1,16 +1,21 @@
 namespace NEventStore
 {
+    using Logging;
     using NEventStore.Serialization;
 
     public static class SerializationWireupExtensions
     {
+        private static readonly ILog Logger = LogFactory.BuildLogger(typeof(PersistenceWireup));
+
         public static SerializationWireup UsingBinarySerialization(this PersistenceWireup wireup)
         {
-            return wireup.UsingCustomSerialization(new BinarySerializer());
+            Logger.Info(Resources.WireupSetSerializer, "Binary");
+            return new SerializationWireup(wireup, new BinarySerializer());
         }
 
         public static SerializationWireup UsingCustomSerialization(this PersistenceWireup wireup, ISerialize serializer)
         {
+            Logger.Info(Resources.WireupSetSerializer, "Custom" + serializer.GetType());
             return new SerializationWireup(wireup, serializer);
         }
 

--- a/src/NEventStore/Wireup.cs
+++ b/src/NEventStore/Wireup.cs
@@ -6,11 +6,14 @@ namespace NEventStore
     using NEventStore.Conversion;
     using NEventStore.Persistence;
     using NEventStore.Persistence.InMemory;
+    using NEventStore.Serialization;
+    using Logging;
 
     public class Wireup
     {
         private readonly NanoContainer _container;
         private readonly Wireup _inner;
+        private ILog Logger = LogFactory.BuildLogger(typeof(Wireup));
 
         protected Wireup(NanoContainer container)
         {
@@ -51,6 +54,7 @@ namespace NEventStore
 
         public virtual Wireup HookIntoPipelineUsing(params IPipelineHook[] hooks)
         {
+            Logger.Info(Resources.WireupHookIntoPipeline, string.Join(", ", hooks.Select(h => h.GetType())));
             ICollection<IPipelineHook> collection = (hooks ?? new IPipelineHook[] { }).Where(x => x != null).ToArray();
             Container.Register(collection);
             return this;


### PR DESCRIPTION
In this branch I've done some modification to the logging funcions of NES.

1) All basic logger now inherits from a base logger class that allow for the caller to choose log level.
2) Lots of Debug log events are converted to verbose #289
3) Added several Info logs to track all initialization of  the engine.