### PR TITLE
Correct assembly load log message in EventUpconverterWireup

### DIFF
--- a/src/NEventStore/EventUpconverterWireup.cs
+++ b/src/NEventStore/EventUpconverterWireup.cs
@@ -85,8 +85,13 @@ namespace NEventStore
 
         public virtual EventUpconverterWireup WithConvertersFrom(params Assembly[] assemblies)
         {
-            if (Logger.IsDebugEnabled) Logger.Debug(Messages.EventUpconvertersLoadedFrom, string.Concat(", ", assemblies));
+            if (Logger.IsDebugEnabled)
+            {
+                Logger.Debug(Messages.EventUpconvertersLoadedFrom,
+                    string.Join(", ", assemblies.Select(a => $"{a.GetName().Name} {a.GetName().Version}")));
+            }
             _assembliesToScan.AddRange(assemblies);
+            
             return this;
         }
 
@@ -97,9 +102,7 @@ namespace NEventStore
 #else
             IEnumerable<Assembly> assemblies = converters.Select(c => c.GetTypeInfo().Assembly).Distinct();
 #endif
-            if (Logger.IsDebugEnabled) Logger.Debug(Messages.EventUpconvertersLoadedFrom, string.Concat(", ", assemblies));
-            _assembliesToScan.AddRange(assemblies);
-            return this;
+            return this.WithConvertersFrom(assemblies.ToArray());
         }
 
         public virtual EventUpconverterWireup AddConverter<TSource, TTarget>(


### PR DESCRIPTION
string.Concat ends up with ", System.Reflection.Assembly[]"
see: https://dotnetfiddle.net/7S65fu