### PR TITLE
Updated GetSnapshot method

### DIFF
--- a/src/NEventStore/Persistence/InMemory/InMemoryPersistenceEngine.cs
+++ b/src/NEventStore/Persistence/InMemory/InMemoryPersistenceEngine.cs
@@ -431,6 +431,7 @@ namespace NEventStore.Persistence.InMemory
                 {
                     return _snapshots
                         .Where(x => x.StreamId == streamId && x.StreamRevision <= maxRevision)
+                        .Reverse()
                         .OrderByDescending(x => x.StreamRevision)
                         .FirstOrDefault();
                 }


### PR DESCRIPTION
Currently, if two or more snapshots are added for a stream with same streamRevision using AddSnapshot method, both of them will be stored in the `_snapshots` collection. While retrieving snapshot for that streamRevision, the one which was added earlier in time will be returned from `GetSnapshot`.
I follow the MongoDB persistence engine and observe that `AddSnapshot` does an [update](https://github.com/NEventStore/NEventStore.Persistence.MongoDB/blob/master/src/NEventStore.Persistence.MongoDB/MongoPersistenceEngine.cs#L515) instead of persisting all snapshots with same `streamId` and `streamRevision`.  
Therefore, the InMemory persistence behaves differently when compared to MongoDB persistence. 

With this change, the `GetSnapshot` has been modified to give the most recent added snapshot when there are more than one snapshots for same streamId and streamRevision.